### PR TITLE
Add check for bug status in compare-bug-version-and-git-branch.sh 

### DIFF
--- a/compare-bug-version-and-git-branch.sh
+++ b/compare-bug-version-and-git-branch.sh
@@ -36,11 +36,17 @@ while [ -z "${BUG_PRODUCT}" -a ${BZQTRY} -le 3 ]; do
         echo 1
     fi
 
-    BZQOUT=$(bugzilla ${BZQOPTS} query -b ${BUG} --outputformat='%{product}:%{version}:%{groups}')
+    BZQOUT=$(bugzilla ${BZQOPTS} query -b ${BUG} --outputformat='%{product}:%{version}:%{groups}:%{status}')
     BUG_PRODUCT=$(cut -d: -f1 <<< "${BZQOUT}")
     BUG_VERSION=$(cut -d: -f2 <<< "${BZQOUT}")
     BUG_GROUPS=$(cut -d: -f3 <<< "${BZQOUT}")
+    BUG_STATUS=$(cut -d: -f4 <<< "${BZQOUT}")
 done
+
+if [ "${BUG_STATUS}" != "NEW" -a "${BUG_STATUS}" != "POST" -a "${BUG_STATUS}" != "ASSIGNED" ]; then
+    echo "BUG id ${BUG} has an invalid status as ${BUG_STATUS}. Acceptable status values are NEW, ASSIGNED or POST."
+    exit 1
+fi
 
 if [ "${BUG_GROUPS}" != '[]' ]; then
     echo "BUG id ${BUG} is marked private, please remove the groups."


### PR DESCRIPTION
Currently compare-bug-version-and-git-branch smoke test does not check for the bug status. As a result it is very well possible that a patch/change submitted against a BZ under CLOSED status could bypass this test and proceed assuming success. This change will add an additional check for bug status. Please see the following link for more details on bug status life cycle:

http://gluster.readthedocs.org/en/latest/Contributors-Guide/Bug-report-Life-Cycle/

fixes gluster/release-tools#3

Signed-off-by: Anoop C S <anoopcs@redhat.com>