### PR TITLE
centos-ci: add libgfapi-python test-case

### DIFF
--- a/centos-ci/README.md
+++ b/centos-ci/README.md
@@ -1,0 +1,19 @@
+# Jenkins jobs and scripts for testing Gluster in the CentOS CI
+
+This directory contains the configuration and scripts that get executed in the
+[CentOS CI](https://ci.centos.org/view/Gluster/). The tests are maintained by
+the Gluster Community, questions or comments about these tests should be sent
+to the [main Gluster developers
+list](http://www.gluster.org/mailman/listinfo/gluster-devel). Changes to the
+test-cases can be sent as GitHub pull requests.
+
+# Current available tests
+
+## libgfapi-python
+Run the upstream functional tests from the
+(libgfapi-python)[https://github.com/gluster/libgfapi-python] master branch on
+a single brick volume. This test currently installs the latest released version
+of GlusterFS from the CentOS Storage SIG. In future it should use the nightly
+builds from an other CentOS CI job that places the RPMs on
+http://artifacts.ci.centos.org/gluster/
+

--- a/centos-ci/libgfapi-python/gluster_libgfapi-python.xml
+++ b/centos-ci/libgfapi-python/gluster_libgfapi-python.xml
@@ -1,0 +1,87 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Run the functional test from libgfapi-python against the latest build of the glusterfs packages.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.17.1">
+      <projectUrl>https://github.com/gluster/libgfapi-python/</projectUrl>
+      <displayName></displayName>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.15">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>TEST_SCRIPT</name>
+          <description>Test script to execute on the reserved machine, should move to the gluster/glusterfs-patch-acceptance-tests at one point.</description>
+          <defaultValue>https://raw.githubusercontent.com/nixpanic/glusterfs-patch-acceptance-tests/centos-ci/libgfapi-python/centos-ci/libgfapi-python/run-test.sh</defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <assignedNode>gluster</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.plugins.python.Python plugin="python@1.2">
+      <command>#
+# from: https://raw.githubusercontent.com/kbsingh/centos-ci-scripts/master/build_python_script.py
+#
+# This script uses the Duffy node management api to get fresh machines to run
+# your CI tests on. Once allocated you will be able to ssh into that machine
+# as the root user and setup the environ
+#
+# XXX: You need to add your own api key below, and also set the right cmd= line 
+#      needed to run the tests
+#
+# Please note, this is a basic script, there is no error handling and there are
+# no real tests for any exceptions. Patches welcome!
+
+import json, urllib, subprocess, sys, os
+
+url_base=&quot;http://admin.ci.centos.org:8080&quot;
+ver=&quot;7&quot;
+arch=&quot;x86_64&quot;
+count=1
+script_url=os.getenv(&quot;TEST_SCRIPT&quot;)
+
+# read the API key for Duffy from the ~/duffy.key file
+fo=open(&quot;/home/gluster/duffy.key&quot;)
+api=fo.read().strip()
+fo.close()
+
+# build the URL to request the system(s)
+get_nodes_url=&quot;%s/Node/get?key=%s&amp;ver=%s&amp;arch=%s&amp;count=%s&quot; % (url_base,api,ver,arch,count)
+
+# request the system
+dat=urllib.urlopen(get_nodes_url).read()
+b=json.loads(dat)
+cmd=&quot;&quot;&quot;ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s &apos;
+	yum -y install curl &amp;&amp;
+	curl %s | bash -
+&apos;&quot;&quot;&quot; % (b[&apos;hosts&apos;][0], script_url)
+print cmd
+rtn_code=subprocess.call(cmd, shell=True)
+
+# return the system(s) to duffy
+done_nodes_url=&quot;%s/Node/done?key=%s&amp;ssid=%s&quot; % (url_base, api, b[&apos;ssid&apos;])
+das=urllib.urlopen(done_nodes_url).read()
+
+sys.exit(rtn_code)
+</command>
+    </hudson.plugins.python.Python>
+  </builders>
+  <publishers/>
+  <buildWrappers>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.1">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
+</project>

--- a/centos-ci/libgfapi-python/run-test.sh
+++ b/centos-ci/libgfapi-python/run-test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# if anything fails, we'll abort
+set -e
+
+# install a Gluster server
+yum -y install centos-release-gluster && yum -y install glusterfs-server glusterfs-cli
+systemctl start glusterd
+
+# create a brick
+truncate --size=8G /srv/test.brick.img
+mkfs -t xfs /srv/test.brick.img
+mkdir -p /bricks/test
+mount -o loop /srv/test.brick.img /bricks/test
+
+# create a volume ("test" is the default name in test/test.conf)
+gluster --mode=script volume create test ${HOSTNAME}:/bricks/test/data
+gluster --mode=script volume start test
+
+# basic dependencies for the tests
+yum -y install git
+yum -y install /usr/bin/easy_install
+easy_install pip
+pip install --upgrade "tox>=1.6,<1.7" "virtualenv>=1.10,<1.11" nose
+
+git clone https://review.gluster.org/libgfapi-python
+cd libgfapi-python/
+
+# installing mock through "tox" fails, do it manually
+pip install --upgrade mock
+sed -i '/mock/d' test-requirements.txt
+
+# nosetests on CentOS-7 does not like --with-html-output and --html-out-file
+sed -i 's/--with-html-output//' tox.ini
+sed -i -e '/--with-html-output/d' -e '/--html-out-file/d' functional_tests.sh
+
+# run the functional test (others fail due to deps?)
+tox -e functest


### PR DESCRIPTION
Initial test for libgfapi-python. This runs the upstream libgfapi-python
functional test. The Jenkins job (gluster_libgfapi-python.xml) reserves
a machine, downloads and executes the run-test.sh script from GitHub.

URL: https://ci.centos.org/view/Gluster/job/gluster_libgfapi-python/
Signed-off-by: Niels de Vos <ndevos@redhat.com>