### PR TITLE
centos-ci/libgfapi-python: run all tests

### DIFF
--- a/centos-ci/libgfapi-python/gluster_libgfapi-python.xml
+++ b/centos-ci/libgfapi-python/gluster_libgfapi-python.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project>
   <actions/>
-  <description>Run the functional test from libgfapi-python against the latest build of the glusterfs packages.</description>
+  <description>Run the functional test from libgfapi-python against the latest build of the glusterfs packages. A new run is executed automatically against the nightly builds of the master branch.</description>
   <keepDependencies>false</keepDependencies>
   <properties>
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.17.1">
@@ -14,9 +14,14 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>DUFFY_SCRIPT</name>
+          <description>Python script that reserves a machine from Duffy.</description>
+          <defaultValue>https://raw.githubusercontent.com/gluster/glusterfs-patch-acceptance-tests/master/centos-ci/libgfapi-python/jenkins-job.py</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>TEST_SCRIPT</name>
-          <description>Test script to execute on the reserved machine, should move to the gluster/glusterfs-patch-acceptance-tests at one point.</description>
-          <defaultValue>https://raw.githubusercontent.com/nixpanic/glusterfs-patch-acceptance-tests/centos-ci/libgfapi-python/centos-ci/libgfapi-python/run-test.sh</defaultValue>
+          <description>Test script to execute on the reserved machine.</description>
+          <defaultValue>https://raw.githubusercontent.com/gluster/glusterfs-patch-acceptance-tests/master/centos-ci/libgfapi-python/run-test.sh</defaultValue>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
@@ -27,56 +32,33 @@
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <triggers/>
+  <triggers>
+    <org.jenkinsci.plugins.urltrigger.URLTrigger plugin="urltrigger@0.40">
+      <spec># run every two hours
+H */2 * * *</spec>
+      <triggerLabel>gluster</triggerLabel>
+      <entries>
+        <org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+          <url>http://artifacts.ci.centos.org/gluster/nightly/master/7/x86_64/repodata/repomd.xml</url>
+          <proxyActivated>false</proxyActivated>
+          <checkStatus>false</checkStatus>
+          <statusCode>200</statusCode>
+          <timeout>300</timeout>
+          <checkETag>false</checkETag>
+          <checkLastModificationDate>true</checkLastModificationDate>
+          <inspectingContent>false</inspectingContent>
+          <contentTypes/>
+        </org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+      </entries>
+      <labelRestriction>true</labelRestriction>
+    </org.jenkinsci.plugins.urltrigger.URLTrigger>
+  </triggers>
   <concurrentBuild>false</concurrentBuild>
   <builders>
-    <hudson.plugins.python.Python plugin="python@1.2">
-      <command>#
-# from: https://raw.githubusercontent.com/kbsingh/centos-ci-scripts/master/build_python_script.py
-#
-# This script uses the Duffy node management api to get fresh machines to run
-# your CI tests on. Once allocated you will be able to ssh into that machine
-# as the root user and setup the environ
-#
-# XXX: You need to add your own api key below, and also set the right cmd= line 
-#      needed to run the tests
-#
-# Please note, this is a basic script, there is no error handling and there are
-# no real tests for any exceptions. Patches welcome!
-
-import json, urllib, subprocess, sys, os
-
-url_base=&quot;http://admin.ci.centos.org:8080&quot;
-ver=&quot;7&quot;
-arch=&quot;x86_64&quot;
-count=1
-script_url=os.getenv(&quot;TEST_SCRIPT&quot;)
-
-# read the API key for Duffy from the ~/duffy.key file
-fo=open(&quot;/home/gluster/duffy.key&quot;)
-api=fo.read().strip()
-fo.close()
-
-# build the URL to request the system(s)
-get_nodes_url=&quot;%s/Node/get?key=%s&amp;ver=%s&amp;arch=%s&amp;count=%s&quot; % (url_base,api,ver,arch,count)
-
-# request the system
-dat=urllib.urlopen(get_nodes_url).read()
-b=json.loads(dat)
-cmd=&quot;&quot;&quot;ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s &apos;
-	yum -y install curl &amp;&amp;
-	curl %s | bash -
-&apos;&quot;&quot;&quot; % (b[&apos;hosts&apos;][0], script_url)
-print cmd
-rtn_code=subprocess.call(cmd, shell=True)
-
-# return the system(s) to duffy
-done_nodes_url=&quot;%s/Node/done?key=%s&amp;ssid=%s&quot; % (url_base, api, b[&apos;ssid&apos;])
-das=urllib.urlopen(done_nodes_url).read()
-
-sys.exit(rtn_code)
-</command>
-    </hudson.plugins.python.Python>
+    <hudson.tasks.Shell>
+      <command>curl -o jenkins-job.py ${DUFFY_SCRIPT}
+python jenkins-job.py</command>
+    </hudson.tasks.Shell>
   </builders>
   <publishers/>
   <buildWrappers>

--- a/centos-ci/libgfapi-python/jenkins-job.py
+++ b/centos-ci/libgfapi-python/jenkins-job.py
@@ -1,0 +1,48 @@
+#
+# from: https://raw.githubusercontent.com/kbsingh/centos-ci-scripts/master/build_python_script.py
+#
+# This script uses the Duffy node management api to get fresh machines to run
+# your CI tests on. Once allocated you will be able to ssh into that machine
+# as the root user and setup the environ
+#
+# XXX: You need to add your own api key below, and also set the right cmd= line 
+#      needed to run the tests
+#
+# Please note, this is a basic script, there is no error handling and there are
+# no real tests for any exceptions. Patches welcome!
+
+import json, urllib, subprocess, sys, os
+
+print ""
+print "This test is part of the Gluster Jenkins jobs that can be found on GitHub:"
+print " - https://github.com/gluster/glusterfs-patch-acceptance-tests/tree/master/centos-ci"
+print ""
+
+url_base="http://admin.ci.centos.org:8080"
+ver="7"
+arch="x86_64"
+count=1
+script_url=os.getenv("TEST_SCRIPT")
+
+# read the API key for Duffy from the ~/duffy.key file
+fo=open("/home/gluster/duffy.key")
+api=fo.read().strip()
+fo.close()
+
+# build the URL to request the system(s)
+get_nodes_url="%s/Node/get?key=%s&ver=%s&arch=%s&count=%s" % (url_base,api,ver,arch,count)
+
+# request the system
+dat=urllib.urlopen(get_nodes_url).read()
+b=json.loads(dat)
+cmd="""ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s '
+	yum -y install curl &&
+	curl %s | bash -
+'""" % (b['hosts'][0], script_url)
+rtn_code=subprocess.call(cmd, shell=True)
+
+# return the system(s) to duffy
+done_nodes_url="%s/Node/done?key=%s&ssid=%s" % (url_base, api, b['ssid'])
+das=urllib.urlopen(done_nodes_url).read()
+
+sys.exit(rtn_code)

--- a/centos-ci/libgfapi-python/run-test.sh
+++ b/centos-ci/libgfapi-python/run-test.sh
@@ -4,35 +4,33 @@
 set -e
 
 # install a Gluster server
-yum -y install centos-release-gluster && yum -y install glusterfs-server glusterfs-cli
+yum -y install centos-release-gluster yum-utils
+yum-config-manager --add-repo=http://artifacts.ci.centos.org/gluster/nightly/master.repo
+yum -y install glusterfs-server glusterfs-cli
 systemctl start glusterd
 
-# create a brick
-truncate --size=8G /srv/test.brick.img
-mkfs -t xfs /srv/test.brick.img
-mkdir -p /bricks/test
-mount -o loop /srv/test.brick.img /bricks/test
+# create bricks
+for i in {1..4}
+do
+    truncate --size=2G /srv/test.brick${i}.img;
+    mkfs -t xfs /srv/test.brick${i}.img;
+    mkdir -p /bricks/b${i};
+    mount -o loop /srv/test.brick${i}.img /bricks/b${i};
+    mkdir /bricks/b${i}/data;
+done
 
 # create a volume ("test" is the default name in test/test.conf)
-gluster --mode=script volume create test ${HOSTNAME}:/bricks/test/data
+gluster --mode=script volume create test replica 2 ${HOSTNAME}:/bricks/b{1..4}/data force
 gluster --mode=script volume start test
 
 # basic dependencies for the tests
 yum -y install git
 yum -y install /usr/bin/easy_install
 easy_install pip
-pip install --upgrade "tox>=1.6,<1.7" "virtualenv>=1.10,<1.11" nose
+pip install --upgrade pip tox
 
 git clone https://review.gluster.org/libgfapi-python
 cd libgfapi-python/
 
-# installing mock through "tox" fails, do it manually
-pip install --upgrade mock
-sed -i '/mock/d' test-requirements.txt
-
-# nosetests on CentOS-7 does not like --with-html-output and --html-out-file
-sed -i 's/--with-html-output//' tox.ini
-sed -i -e '/--with-html-output/d' -e '/--html-out-file/d' functional_tests.sh
-
-# run the functional test (others fail due to deps?)
-tox -e functest
+# run tests
+tox -e pep8,py27,functest


### PR DESCRIPTION
libgfapi-python was updated so that there are no changes needed to the
tox configuration and other files before running the tests.

This change also moves the resevation of the machine through Duffy from
the Jenkins job itself (the .xml file), into jenkins-job.py.

Signed-off-by: Niels de Vos <ndevos@redhat.com>