### PR TITLE
centos-ci: add nightly build job

### DIFF
--- a/centos-ci/README.md
+++ b/centos-ci/README.md
@@ -9,6 +9,13 @@ test-cases can be sent as GitHub pull requests.
 
 # Current available tests
 
+## nightly-builds
+Create RPMs each night and sync them to artifacts.ci.centos.org. There is one
+main job is used as a scheduler (`gluster_nightly-rpm-builds`). The actual
+building is done by `gluster_build-rpms` and uses several environment
+parameters to decide what CentOS version, architecture and Gluster release to
+build.
+
 ## libgfapi-python
 Run the upstream functional tests from the
 [libgfapi-python](https://github.com/gluster/libgfapi-python) master branch on

--- a/centos-ci/nighly-builds/build.sh
+++ b/centos-ci/nighly-builds/build.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+artifact()
+{
+	[ -e ~/rsync.passwd ] || return 0
+	rsync -av --password-file ~/rsync.passwd ${@} gluster@artifacts.ci.centos.org::gluster/nightly/
+}
+
+# if anything fails, we'll abort
+set -e
+
+# install basic dependencies for building the tarball and srpm
+yum -y install git autoconf automake gcc libtool bison flex make rpm-build mock createrepo_c
+# gluster repositories contain additional -devel packages
+yum -y install centos-release-gluster
+yum -y install python-devel libaio-devel librdmacm-devel libattr-devel libxml2-devel readline-devel openssl-devel libibverbs-devel fuse-devel glib2-devel userspace-rcu-devel libacl-devel sqlite-devel
+
+# clone the repository, github is faster than our Gerrit
+#git clone https://review.gluster.org/glusterfs
+git clone https://github.com/gluster/glusterfs
+cd glusterfs/
+
+# switch to the branch we want to build
+git checkout ${GERRIT_BRANCH}
+
+# generate a version based on branch.date.last-commit-hash
+if [ ${GERRIT_BRANCH} = 'master' ]; then
+	GIT_VERSION=''
+	GIT_HASH="$(git log -1 --format=%h)"
+	VERSION="$(date +%Y%m%d).${GIT_HASH}"
+else
+	GIT_VERSION="$(sed 's/.*-//' <<< ${GERRIT_BRANCH})"
+	GIT_HASH="$(git log -1 --format=%h)"
+	VERSION="${GIT_VERSION}.$(date +%Y%m%d).${GIT_HASH}"
+fi
+
+# overload some variables to match the auto-generated version
+if [ -x build-aux/pkg-version ]; then
+	VERSION="$(build-aux/pkg-version --version)"
+fi
+
+# unique tag to use in git
+TAG="${VERSION}-$(date +%Y%m%d).${GIT_HASH}"
+
+if grep -q -E '^AC_INIT\(.*\)$' configure.ac; then
+	# replace the default version by our autobuild one
+	sed -i "s/^AC_INIT(.*)$/AC_INIT([glusterfs],[${VERSION}],[gluster-devel@gluster.org])/" configure.ac
+
+	# Add a note to the ChangeLog (generated with 'make dist')
+	git commit -q -n --author='Autobuild <gluster-devel@gluster.org>' \
+		-m "autobuild: set version to ${VERSION}" configure.ac
+fi
+
+# generate the tar.gz archive
+./autogen.sh
+./configure
+rm -f *.tar.gz
+make dist
+
+# build the SRPM
+rm -f *.src.rpm
+SRPM=$(rpmbuild --define 'dist .autobuild' --define "_srcrpmdir ${PWD}" \
+	--define '_source_payload w9.gzdio' \
+	--define '_source_filedigest_algorithm 1' \
+	-ts glusterfs-${VERSION}.tar.gz | cut -d' ' -f 2)
+
+# do the actual RPM build in mock
+# TODO: use a CentOS Storage SIG buildroot
+source /etc/os-release
+RESULTDIR=/srv/gluster/nightly/${GERRIT_BRANCH}/${VERSION_ID}/$(uname -m)
+/usr/bin/mock \
+	--root epel-${VERSION_ID}-$(uname -m) \
+	--resultdir ${RESULTDIR} \
+	--rebuild ${SRPM}
+
+pushd ${RESULTDIR}
+createrepo_c .
+popd
+
+pushd /srv/gluster/nightly
+artifact ${GERRIT_BRANCH}
+popd
+
+exit ${RET}
+

--- a/centos-ci/nighly-builds/gluster_build-rpms.xml
+++ b/centos-ci/nighly-builds/gluster_build-rpms.xml
@@ -1,0 +1,76 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Build RPMs from the master branch, each night.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.17.1">
+      <projectUrl>https://github.com/gluster/glusterfs/</projectUrl>
+      <displayName></displayName>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.15">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>DUFFY_SCRIPT</name>
+          <description>Python script that reserves a machine from Duffy and starts the ${TEST_SCRIPT}.</description>
+          <defaultValue>https://raw.githubusercontent.com/gluster/glusterfs-patch-acceptance-tests/master/centos-ci/nightly-builds/jenkins-job.py</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>TEST_SCRIPT</name>
+          <description>Test script to execute on the reserved machine, should move to the gluster/glusterfs-patch-acceptance-tests at one point.</description>
+          <defaultValue>https://raw.githubusercontent.com/gluster/glusterfs-patch-acceptance-tests/master/centos-ci/nightly-builds/build.sh</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>GERRIT_BRANCH</name>
+          <description>Branch from the upstream git repository to build RPMs from.</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>master</string>
+              <string>release-3.7</string>
+              <string>release-3.6</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CENTOS_VERSION</name>
+          <description>CentOS version to build the RPMs for.</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>7</string>
+              <string>6</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.ChoiceParameterDefinition>
+          <name>CENTOS_ARCH</name>
+          <description>CentOS architecture to build the RPMs for.</description>
+          <choices class="java.util.Arrays$ArrayList">
+            <a class="string-array">
+              <string>x86_64</string>
+              <string>i686</string>
+            </a>
+          </choices>
+        </hudson.model.ChoiceParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <assignedNode>gluster</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>curl -o jenkins-job.py ${DUFFY_SCRIPT}
+python jenkins-job.py</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/centos-ci/nighly-builds/gluster_nightly-rpm-builds.xml
+++ b/centos-ci/nighly-builds/gluster_nightly-rpm-builds.xml
@@ -1,0 +1,84 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<com.tikal.jenkins.plugins.multijob.MultiJobProject plugin="jenkins-multijob-plugin@1.18">
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.15">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <assignedNode>gluster</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <hudson.triggers.TimerTrigger>
+      <spec>@midnight</spec>
+    </hudson.triggers.TimerTrigger>
+  </triggers>
+  <concurrentBuild>true</concurrentBuild>
+  <builders>
+    <hudson.plugins.parameterizedtrigger.TriggerBuilder plugin="parameterized-trigger@2.29">
+      <configs>
+        <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>CENTOS_VERSION=7
+CENTOS_ARCH=x86_64
+GERRIT_BRANCH=master</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>gluster_build-rpms</projects>
+          <condition>ALWAYS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
+        </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>CENTOS_VERSION=6
+CENTOS_ARCH=x86_64
+GERRIT_BRANCH=master</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>gluster_build-rpms</projects>
+          <condition>ALWAYS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
+        </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>CENTOS_VERSION=7
+CENTOS_ARCH=x86_64
+GERRIT_BRANCH=release-3.7</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>gluster_build-rpms</projects>
+          <condition>ALWAYS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
+        </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>CENTOS_VERSION=6
+CENTOS_ARCH=x86_64
+GERRIT_BRANCH=release-3.7</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>gluster_build-rpms</projects>
+          <condition>ALWAYS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
+        </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+      </configs>
+    </hudson.plugins.parameterizedtrigger.TriggerBuilder>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+  <pollSubjobs>false</pollSubjobs>
+</com.tikal.jenkins.plugins.multijob.MultiJobProject>

--- a/centos-ci/nighly-builds/jenkins-job.py
+++ b/centos-ci/nighly-builds/jenkins-job.py
@@ -1,0 +1,49 @@
+#
+# from: https://raw.githubusercontent.com/kbsingh/centos-ci-scripts/master/build_python_script.py
+#
+# This script uses the Duffy node management api to get fresh machines to run
+# your CI tests on. Once allocated you will be able to ssh into that machine
+# as the root user and setup the environ
+#
+# XXX: You need to add your own api key below, and also set the right cmd= line 
+#      needed to run the tests
+#
+# Please note, this is a basic script, there is no error handling and there are
+# no real tests for any exceptions. Patches welcome!
+
+import json, urllib, subprocess, sys, os
+
+url_base="http://admin.ci.centos.org:8080"
+ver=os.getenv("CENTOS_VERSION")
+arch=os.getenv("CENTOS_ARCH")
+count=1
+script_url=os.getenv("TEST_SCRIPT")
+
+# read the API key for Duffy from the ~/duffy.key file
+fo=open("/home/gluster/duffy.key")
+api=fo.read().strip()
+fo.close()
+
+# build the URL to request the system(s)
+get_nodes_url="%s/Node/get?key=%s&ver=%s&arch=%s&count=%s" % (url_base,api,ver,arch,count)
+
+# request the system
+dat=urllib.urlopen(get_nodes_url).read()
+b=json.loads(dat)
+
+# create a rsync.passwd file on the reserved system to store RPMs on artifacts.ci.centos.org
+cmd="cut -c1-13 < ~/duffy.key | ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s 'cat > rsync.passwd ; chmod 0600 rsync.passwd'" % (b['hosts'][0])
+rtn_code=subprocess.call(cmd, shell=True)
+
+cmd="""ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s '
+	yum -y install curl &&
+	curl -o build.sh %s &&
+	GERRIT_BRANCH="%s" bash build.sh'
+""" % (b['hosts'][0], script_url, os.getenv("GERRIT_BRANCH"))
+rtn_code=subprocess.call(cmd, shell=True)
+
+# return the system(s) to duffy
+done_nodes_url="%s/Node/done?key=%s&ssid=%s" % (url_base, api, b['ssid'])
+das=urllib.urlopen(done_nodes_url).read()
+
+sys.exit(rtn_code)


### PR DESCRIPTION
Build the HEAD of the master branch in mock agains epel-7-x86_64. Other
branches and CentOS versions/architectures can be selected with
environment variables.

The RPMs are published on http://artifacts.ci.centos.org/gluster/nightly

Other tests can monitor the repomd.xml file on the artifacts webserver
and use that as trigger to start testing. For each branch there is a
.repo file under http://artifacts.ci.centos.org/gluster/nightly/ . This
file can be used to install the nightly builds. On CentOS one would do
this:

  # yum -y install centos-release-gluser yum-utils
  # yum-config-manager --add-repo=http://artifacts.ci.centos.org/gluster/nightly/master.repo
  # yum -y install glusterfs-server

Signed-off-by: Niels de Vos <ndevos@redhat.com>