### PR TITLE
centos-ci: add clang-analysis job

### DIFF
--- a/centos-ci/clang-analysis/gluster_clang-analysis.xml
+++ b/centos-ci/clang-analysis/gluster_clang-analysis.xml
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <description>Run clang static analysis tool scan-build, triggerered on every gerrit CR revision</description>⇂
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.17.1">
+        <projectUrl>https://github.com/gluster/glusterfs</projectUrl>
+      <displayName></displayName>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.15">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>DUFFY_SCRIPT</name>
+          <description>Python script that reserves a machine from Duffy.</description>
+          <defaultValue>https://raw.githubusercontent.com/gluster/glusterfs-patch-acceptance-tests/master/centos-ci/clang-analysis/jenkins-job.py</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>TEST_SCRIPT</name>
+          <description>Test script to execute on the reserved machine.</description>
+          <defaultValue>https://raw.githubusercontent.com/gluster/glusterfs-patch-acceptance-tests/master/centos-ci/clang-analysis/run-clang-analysis.sh</defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <assignedNode>gluster</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+      <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger plugin="gerrit-trigger@2.18.3">
+          <spec></spec>
+          <gerritProjects>
+              <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
+                  <compareType>PLAIN</compareType>
+                  <pattern>glusterfs</pattern>
+                  <branches>
+                      <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.Branch>
+                          <compareType>ANT</compareType>
+                          <pattern>**</pattern>
+                      </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.Branch>
+                  </branches>
+                  <disableStrictForbiddenFileVerification>false</disableStrictForbiddenFileVerification>
+              </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject>
+          </gerritProjects>
+          <skipVote>
+              <onSuccessful>false</onSuccessful>
+              <onFailed>false</onFailed>
+              <onUnstable>false</onUnstable>
+              <onNotBuilt>false</onNotBuilt>
+          </skipVote>
+          <silentMode>false</silentMode>
+          <notificationLevel></notificationLevel>
+          <silentStartMode>false</silentStartMode>
+          <escapeQuotes>true</escapeQuotes>
+          <nameAndEmailParameterMode>PLAIN</nameAndEmailParameterMode>
+          <dependencyJobsNames></dependencyJobsNames>
+          <commitMessageParameterMode>BASE64</commitMessageParameterMode>
+          <changeSubjectParameterMode>PLAIN</changeSubjectParameterMode>
+          <buildStartMessage></buildStartMessage>
+          <buildFailureMessage></buildFailureMessage>
+          <buildSuccessfulMessage></buildSuccessfulMessage>
+          <buildUnstableMessage></buildUnstableMessage>
+          <buildNotBuiltMessage></buildNotBuiltMessage>
+          <buildUnsuccessfulFilepath></buildUnsuccessfulFilepath>
+          <customUrl></customUrl>
+          <serverName>review.gluster.org</serverName>
+          <triggerOnEvents>
+              <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent>
+                  <excludeDrafts>false</excludeDrafts>
+                  <excludeTrivialRebase>false</excludeTrivialRebase>
+                  <excludeNoCodeChange>false</excludeNoCodeChange>
+              </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent>
+              <com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedContainsEvent>
+                  <commentAddedCommentContains>recheck clang</commentAddedCommentContains>
+              </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedContainsEvent>
+          </triggerOnEvents>
+          <dynamicTriggerConfiguration>false</dynamicTriggerConfiguration>
+          <triggerConfigURL></triggerConfigURL>
+          <triggerInformationAction/>
+      </com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>curl -o jenkins-job.py ${DUFFY_SCRIPT}
+python jenkins-job.py</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <buildWrappers>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.1">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
+</project>

--- a/centos-ci/clang-analysis/jenkins-job.py
+++ b/centos-ci/clang-analysis/jenkins-job.py
@@ -1,0 +1,60 @@
+#
+# from: https://raw.githubusercontent.com/kbsingh/centos-ci-scripts/master/build_python_script.py
+#
+# This script uses the Duffy node management api to get fresh machines to run
+# your CI tests on. Once allocated you will be able to ssh into that machine
+# as the root user and setup the environ
+#
+# XXX: You need to add your own api key below, and also set the right cmd= line
+#      needed to run the tests
+#
+# Please note, this is a basic script, there is no error handling and there are
+# no real tests for any exceptions. Patches welcome!
+
+import json, urllib, subprocess, sys, os
+
+print ""
+print "This test is part of the Gluster Jenkins jobs that can be found on GitHub:"
+print " - https://github.com/gluster/glusterfs/tree/master/extras"
+print ""
+
+url_base = "http://admin.ci.centos.org:8080"
+ver = "7"
+arch = "x86_64"
+count = 1
+script_url = os.getenv("TEST_SCRIPT")
+burl = os.getenv("BUILD_URL")
+burl += 'consoleFull'
+
+# read the API key for Duffy from the ~/duffy.key file
+fo = open("/home/gluster/duffy.key")
+api = fo.read().strip()
+fo.close()
+
+# build the URL to request the system(s)
+get_nodes_url = "%s/Node/get?key=%s&ver=%s&arch=%s&count=%s" % (url_base, api, ver, arch,count)
+
+# request the system
+dat = urllib.urlopen(get_nodes_url).read()
+b = json.loads(dat)
+cmd = """ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s '
+      yum -y install curl && curl %s | bash - '""" % (b['hosts'][0], script_url)
+rtn_code=subprocess.call(cmd, shell=True)
+
+# Update Gerrit with the success/failure status
+if rtn_code == 0:
+    v = "+1"
+    verdict = "SUCCESS"
+else:
+    v = "-1"
+    verdict = "FAILED"
+
+cmd = "ssh centos-ci@review.gluster.org gerrit review --message \"\'%s : %s\'\" --project=glusterfs --label Clang-analysis=\"%s\" %s" % (burl, verdict, v, os.getenv("GIT_COMMIT"))
+
+subprocess.call(cmd, shell=True)
+
+# return the system(s) to duffy
+done_nodes_url = "%s/Node/done?key=%s&ssid=%s" % (url_base, api, b['ssid'])
+das = urllib.urlopen(done_nodes_url).read()
+
+sys.exit(rtn_code)

--- a/centos-ci/clang-analysis/run-clang-analysis.sh
+++ b/centos-ci/clang-analysis/run-clang-analysis.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# if anything fails, we'll abort
+set -e
+
+function install_dependencies()
+{
+    yum -y install automake autoconf libtool flex bison openssl-devel \
+                libxml2-devel python-devel libaio-devel libibverbs-devel \
+                librdmacm-devel readline-devel lvm2-devel glib2-devel \
+                userspace-rcu-devel libcmocka-devel libacl-devel make \
+                gcc gdb git hostname libattr-devel yajl-devel clang-analyzer
+}
+
+# cleanup leftout jobs
+pkill -f clang-checker.sh
+
+install_dependencies
+
+# clone repo and checkout to commit
+git clone http://review.gluster.org/glusterfs.git
+cd glusterfs
+git fetch http://review.gluster.org/glusterfs ${GERRIT_REFSPEC} && git checkout FETCH_HEAD
+
+# run clang static analyzer
+./autogen.sh
+./configure
+./extras/clang-checker.sh
+
+exit $?
+


### PR DESCRIPTION
This build run
https://github.com/gluster/glusterfs/tree/master/extras/clang-checker.sh
on every gerrit CR revision

clang-checker.sh: runs clang analyzer with and without the
HEAD commit, and shows the bugs introduced by HEAD commit (if any)

Signed-off-by: Prasanna Kumar Kalever prasanna.kalever@redhat.com
