### PR TITLE
Fix FreeBSD builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,25 @@ set -e
 export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"
 
 SRC=$(pwd);
+
+# Get platform-specific values.
+case $(uname -s) in
+    'Linux')
+        nproc=$(getconf _NPROCESSORS_ONLN)
+        bd="yes"
+        werror="-Werror"
+        ;;
+    'NetBSD')
+        nproc=$(getconf NPROCESSORS_ONLN)
+        bd="no"
+        werror=""
+        ;;
+    *)
+        nproc=4
+        bd="no"
+        werror=""
+esac
+
 if type rpm >/dev/null 2>&1; then
     rpm -qa | grep glusterfs | xargs --no-run-if-empty rpm -e
 fi
@@ -15,6 +34,8 @@ rm -rf $P/scratch;
 mkdir -p $P/scratch;
 cd $P/scratch;
 rm -rf $P/install;
-$SRC/configure --prefix=$P/install --with-mountutildir=$P/install/sbin --with-initdir=$P/install/etc --localstatedir=/var --enable-bd-xlator=yes --enable-debug --silent
-make install CFLAGS="-g -O0 -Wall -Werror" -j 4 >/dev/null
+$SRC/configure --prefix=$P/install --with-mountutildir=$P/install/sbin \
+               --with-initdir=$P/install/etc --localstatedir=/var \
+               --enable-bd-xlator=${bd} --enable-debug --silent
+make install CFLAGS="-g -O0 -Wall ${werror}" -j ${nproc}
 cd $SRC;


### PR DESCRIPTION
The two substantive changes are to turn off the BD translator and remove
-Werror (the BSD compilers are pickier than the Linux ones).  Also
removed the redirect to /dev/null because it's actually useful to see
the build results.

Signed-off-by: Jeff Darcy <jdarcy@redhat.com>