### PR TITLE
centis-ci: Add Jenkins job for Heketi functional tests

### DIFF
--- a/centos-ci/README.md
+++ b/centos-ci/README.md
@@ -26,3 +26,17 @@ The job checks every two hours for updates of the [yum
 metadata](http://artifacts.ci.centos.org/gluster/nightly/master/7/x86_64/repodata/repomd.xml)
 for CentOS-7/x86_64 and the nightly Gluster RPMs for the master branch. If the
 metadata has been updated, a new run is attempted.
+
+## heketi-functional
+Run the upstream functional tests as described in the [Heketi
+README](https://github.com/heketi/heketi/blob/master/tests/functional/README.md).
+These tests use [Vagrant from the
+SCLo](https://wiki.centos.org/SpecialInterestGroup/SCLo/Vagrant) that is
+provided in CentOS.
+
+The job checks every two hours for updates of the [yum 
+metadata](http://artifacts.ci.centos.org/gluster/nightly/master/7/x86_64/repodata/repomd.xml)
+for CentOS-7/x86_64 and the nightly Gluster RPMs for the master branch. If the
+metadata has been updated, a new run is attempted. The test run itself [does
+not use the nightly build Gluster repository
+yet](https://github.com/heketi/heketi/issues/396) though.

--- a/centos-ci/heketi-functional/gluster_heketi-functional.xml
+++ b/centos-ci/heketi-functional/gluster_heketi-functional.xml
@@ -1,0 +1,69 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Run the functional test from upstream Heketi against the latest build of the glusterfs packages. A new run is executed automatically against the nightly builds of the master branch.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.17.1">
+      <projectUrl>https://github.com/heketi/heketi/</projectUrl>
+      <displayName></displayName>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.15">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>DUFFY_SCRIPT</name>
+          <description>Python script that reserves a machine from Duffy.</description>
+          <defaultValue>https://raw.githubusercontent.com/gluster/glusterfs-patch-acceptance-tests/master/centos-ci/heketi-functional/jenkins-job.py</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>TEST_SCRIPT</name>
+          <description>Test script to execute on the reserved machine.</description>
+          <defaultValue>https://raw.githubusercontent.com/gluster/glusterfs-patch-acceptance-tests/master/centos-ci/heketi-functional/run-test.sh</defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <assignedNode>gluster</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <org.jenkinsci.plugins.urltrigger.URLTrigger plugin="urltrigger@0.40">
+      <spec># run every two hours
+H */2 * * *</spec>
+      <triggerLabel>gluster</triggerLabel>
+      <entries>
+        <org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+          <url>http://artifacts.ci.centos.org/gluster/nightly/master/7/x86_64/repodata/repomd.xml</url>
+          <proxyActivated>false</proxyActivated>
+          <checkStatus>false</checkStatus>
+          <statusCode>200</statusCode>
+          <timeout>300</timeout>
+          <checkETag>false</checkETag>
+          <checkLastModificationDate>true</checkLastModificationDate>
+          <inspectingContent>false</inspectingContent>
+          <contentTypes/>
+        </org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+      </entries>
+      <labelRestriction>true</labelRestriction>
+    </org.jenkinsci.plugins.urltrigger.URLTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>curl -o jenkins-job.py ${DUFFY_SCRIPT}
+python jenkins-job.py</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.1">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
+</project>

--- a/centos-ci/heketi-functional/jenkins-job.py
+++ b/centos-ci/heketi-functional/jenkins-job.py
@@ -1,0 +1,48 @@
+#
+# from: https://raw.githubusercontent.com/kbsingh/centos-ci-scripts/master/build_python_script.py
+#
+# This script uses the Duffy node management api to get fresh machines to run
+# your CI tests on. Once allocated you will be able to ssh into that machine
+# as the root user and setup the environ
+#
+# XXX: You need to add your own api key below, and also set the right cmd= line 
+#      needed to run the tests
+#
+# Please note, this is a basic script, there is no error handling and there are
+# no real tests for any exceptions. Patches welcome!
+
+import json, urllib, subprocess, sys, os
+
+print ""
+print "This test is part of the Gluster Jenkins jobs that can be found on GitHub:"
+print " - https://github.com/gluster/glusterfs-patch-acceptance-tests/tree/master/centos-ci"
+print ""
+
+url_base="http://admin.ci.centos.org:8080"
+ver="7"
+arch="x86_64"
+count=1
+script_url=os.getenv("TEST_SCRIPT")
+
+# read the API key for Duffy from the ~/duffy.key file
+fo=open("/home/gluster/duffy.key")
+api=fo.read().strip()
+fo.close()
+
+# build the URL to request the system(s)
+get_nodes_url="%s/Node/get?key=%s&ver=%s&arch=%s&count=%s" % (url_base,api,ver,arch,count)
+
+# request the system
+dat=urllib.urlopen(get_nodes_url).read()
+b=json.loads(dat)
+cmd="""ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s '
+	yum -y install curl &&
+	curl %s | bash -
+'""" % (b['hosts'][0], script_url)
+rtn_code=subprocess.call(cmd, shell=True)
+
+# return the system(s) to duffy
+done_nodes_url="%s/Node/done?key=%s&ssid=%s" % (url_base, api, b['ssid'])
+das=urllib.urlopen(done_nodes_url).read()
+
+sys.exit(rtn_code)

--- a/centos-ci/heketi-functional/run-test.sh
+++ b/centos-ci/heketi-functional/run-test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# if anything fails, we'll abort
+set -e
+
+# TODO: disable debugging
+set -x
+
+# enable the SCL repository for Vagrant
+yum -y install centos-release-scl
+
+# install Vagrant with QEMU
+yum -y install qemu-kvm sclo-vagrant1-vagrant-libvirt
+
+# install Go (Heketi depends on version 1.6+)
+if ! yum -y install 'golang >= 1.6'
+then
+	# not the right version, install manually
+	# download URL comes from https://golang.org/dl/
+	curl -O https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz
+	tar xzf go1.6.2.linux-amd64.tar.gz -C /usr/local
+	export PATH=$PATH:/usr/local/go/bin
+fi
+
+# also needs git, gcc and make
+yum -y install git gcc make
+
+# the tests use ansible, that is only available in EPEL
+yum -y install epel-release
+yum -y install ansible
+
+# Vagrant needs libvirtd running
+systemctl start libvirtd
+
+# exact steps from https://github.com/heketi/heketi/tree/master/tests/functional#setup
+mkdir go
+cd go
+export GOPATH=$PWD
+export PATH=$PATH:$GOPATH/bin
+mkdir -p src/github.com/heketi
+cd src/github.com/heketi
+git clone https://github.com/heketi/heketi.git
+go get github.com/robfig/glock
+glock sync github.com/heketi/heketi
+
+# time to run the tests!
+cd $GOPATH/src/github.com/heketi/heketi/tests/functional
+
+# need to prevent sudo from disabling the SCL
+# PR: https://github.com/heketi/heketi/pull/395
+grep -q ^_sudo lib.sh || ( curl https://github.com/heketi/heketi/commit/981f84b2f7cf6ea39754a0fa275fdc86eb3affbb.patch | git apply )
+
+scl enable sclo-vagrant1 ./run.sh
+


### PR DESCRIPTION
There are some improvements that have been requested:
 - https://github.com/heketi/heketi/issues/396
 - https://github.com/heketi/heketi/pull/395

Once these changes have been made, the run-tests.sh script most likely
needs some small updates.

This job is already available in the CentOS CI:
  https://ci.centos.org/view/Gluster/job/gluster_heketi-functional/

Signed-off-by: Niels de Vos <ndevos@redhat.com>