### PR TITLE
centos-ci/heketi-functional: set ghprbPullId to empty string if unset

### DIFF
--- a/centos-ci/heketi-functional/jenkins-job.py
+++ b/centos-ci/heketi-functional/jenkins-job.py
@@ -23,7 +23,7 @@ ver="7"
 arch="x86_64"
 count=1
 script_url=os.getenv("TEST_SCRIPT")
-ghprbPullId=os.getenv("ghprbPullId")
+ghprbPullId=os.getenv("ghprbPullId", "")
 
 # read the API key for Duffy from the ~/duffy.key file
 fo=open("/home/gluster/duffy.key")


### PR DESCRIPTION
In case ghprbPullId is not set in the environment, Python returns None
with os.getenv(). This then translates to the string "None" and the
run-tests.sh script tries to use that as a pull-request number.

Assigning an empty sting in case the envionment variable is not set,
prevents any further issues.

Signed-off-by: Niels de Vos <ndevos@redhat.com>