### PR TITLE
centos-ci/heketi: report test result back to the GitHub pull request

### DIFF
--- a/centos-ci/heketi-functional/gluster_heketi-functional.xml
+++ b/centos-ci/heketi-functional/gluster_heketi-functional.xml
@@ -90,7 +90,15 @@
 python jenkins-job.py</command>
     </hudson.tasks.Shell>
   </builders>
-  <publishers/>
+  <publishers>
+    <org.jenkinsci.plugins.github.status.GitHubCommitStatusSetter plugin="github@1.19.1">
+      <commitShaSource class="org.jenkinsci.plugins.github.status.sources.BuildDataRevisionShaSource"/>
+      <reposSource class="org.jenkinsci.plugins.github.status.sources.AnyDefinedRepositorySource"/>
+      <contextSource class="org.jenkinsci.plugins.github.status.sources.DefaultCommitContextSource"/>
+      <statusResultSource class="org.jenkinsci.plugins.github.status.sources.ConditionalStatusResultSource"/>
+      <errorHandlers/>
+    </org.jenkinsci.plugins.github.status.GitHubCommitStatusSetter>
+  </publishers>
   <buildWrappers>
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
       <colorMapName>xterm</colorMapName>


### PR DESCRIPTION
Enabled a "post-build action":
> Set status for GitHub commit
> "Using GitHub status api sets status of the commit"

Reported-by: Luis Pabón <lpabon@redhat.com>
Tested-by: Luis Pabón <lpabon@redhat.com>
Tested-on: https://github.com/heketi/heketi/pull/420
Signed-off-by: Niels de Vos <ndevos@redhat.com>