### PR TITLE
centos-ci: add job to complain about string formatting warnings

### DIFF
--- a/centos-ci/gluster_strfmt/gluster_strfmt.xml
+++ b/centos-ci/gluster_strfmt/gluster_strfmt.xml
@@ -1,0 +1,106 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Do some checks against the CentOS-6 32-bit build.log for string formatting warnings. A new run is executed automatically against the nightly builds of the master branch.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.19.1">
+      <projectUrl>https://github.com/gluster/glusterfs/</projectUrl>
+      <displayName></displayName>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.17">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>DUFFY_SCRIPT</name>
+          <description>Python script that reserves a machine from Duffy.</description>
+          <defaultValue>https://raw.githubusercontent.com/gluster/glusterfs-patch-acceptance-tests/master/centos-ci/gluster_strfmt/jenkins-job.py</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>TEST_SCRIPT</name>
+          <description>Test script to execute on the reserved machine.</description>
+          <defaultValue>https://raw.githubusercontent.com/gluster/glusterfs-patch-acceptance-tests/master/centos-ci/gluster_strfmt/run-test.sh</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>BUILD_LOG</name>
+          <description>The build.log to check for warnings.</description>
+          <defaultValue>http://artifacts.ci.centos.org/gluster/nightly/master/6/i386/build.log</defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <assignedNode>gluster</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <org.jenkinsci.plugins.urltrigger.URLTrigger plugin="urltrigger@0.40">
+      <spec># run every two hours
+H */2 * * *</spec>
+      <triggerLabel>gluster</triggerLabel>
+      <entries>
+        <org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+          <url>http://artifacts.ci.centos.org/gluster/nightly/master/6/i368/build.log</url>
+          <proxyActivated>false</proxyActivated>
+          <checkStatus>false</checkStatus>
+          <statusCode>200</statusCode>
+          <timeout>300</timeout>
+          <checkETag>false</checkETag>
+          <checkLastModificationDate>true</checkLastModificationDate>
+          <inspectingContent>false</inspectingContent>
+          <contentTypes/>
+        </org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+      </entries>
+      <labelRestriction>true</labelRestriction>
+    </org.jenkinsci.plugins.urltrigger.URLTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>curl -o jenkins-job.py ${DUFFY_SCRIPT}
+python jenkins-job.py</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@2.42">
+      <recipientList>maintainers@gluster.org</recipientList>
+      <configuredTriggers>
+        <hudson.plugins.emailext.plugins.trigger.FailureTrigger>
+          <email>
+            <recipientList>maintainers@gluster.org</recipientList>
+            <subject>$PROJECT_DEFAULT_SUBJECT</subject>
+            <body>$PROJECT_DEFAULT_CONTENT</body>
+            <recipientProviders>
+              <hudson.plugins.emailext.plugins.recipients.DevelopersRecipientProvider/>
+            </recipientProviders>
+            <attachmentsPattern>warnings.txt</attachmentsPattern>
+            <attachBuildLog>false</attachBuildLog>
+            <compressBuildLog>false</compressBuildLog>
+            <replyTo>$PROJECT_DEFAULT_REPLYTO</replyTo>
+            <contentType>project</contentType>
+          </email>
+        </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
+      </configuredTriggers>
+      <contentType>default</contentType>
+      <defaultSubject>$DEFAULT_SUBJECT</defaultSubject>
+      <defaultContent>String formatting warnings have been detected. See the attached warnings.txt for details.</defaultContent>
+      <attachmentsPattern>warnings.txt</attachmentsPattern>
+      <presendScript>$DEFAULT_PRESEND_SCRIPT</presendScript>
+      <postsendScript>$DEFAULT_POSTSEND_SCRIPT</postsendScript>
+      <attachBuildLog>false</attachBuildLog>
+      <compressBuildLog>false</compressBuildLog>
+      <replyTo>maintainers@gluster.org</replyTo>
+      <saveOutput>false</saveOutput>
+      <disabled>false</disabled>
+    </hudson.plugins.emailext.ExtendedEmailPublisher>
+  </publishers>
+  <buildWrappers>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
+</project>

--- a/centos-ci/gluster_strfmt/jenkins-job.py
+++ b/centos-ci/gluster_strfmt/jenkins-job.py
@@ -1,0 +1,50 @@
+#
+# from: https://raw.githubusercontent.com/kbsingh/centos-ci-scripts/master/build_python_script.py
+#
+# This script uses the Duffy node management api to get fresh machines to run
+# your CI tests on. Once allocated you will be able to ssh into that machine
+# as the root user and setup the environ
+#
+# XXX: You need to add your own api key below, and also set the right cmd= line 
+#      needed to run the tests
+#
+# Please note, this is a basic script, there is no error handling and there are
+# no real tests for any exceptions. Patches welcome!
+
+import json, urllib, subprocess, sys, os
+
+url_base="http://admin.ci.centos.org:8080"
+# we just build on CentOS-7/x86_64, CentOS-6 does not have 'mock'?
+ver="7"
+arch="x86_64"
+count=1
+script_url=os.getenv("TEST_SCRIPT")
+
+# read the API key for Duffy from the ~/duffy.key file
+fo=open("/home/gluster/duffy.key")
+api=fo.read().strip()
+fo.close()
+
+# build the URL to request the system(s)
+get_nodes_url="%s/Node/get?key=%s&ver=%s&arch=%s&count=%s" % (url_base,api,ver,arch,count)
+
+# request the system
+dat=urllib.urlopen(get_nodes_url).read()
+b=json.loads(dat)
+
+cmd="""ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s '
+	yum -y install curl &&
+	curl -o build.sh %s &&
+	BUILD_LOG="%s" bash build.sh'
+""" % (b['hosts'][0], script_url, os.getenv("BUILD_LOG"))
+rtn_code=subprocess.call(cmd, shell=True)
+
+if rtn_code != 0:
+    cmd = "scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s:warnings.txt ." % (b['hosts'][0])
+    subprocess.call(cmd, shell=True)
+
+# return the system(s) to duffy
+done_nodes_url="%s/Node/done?key=%s&ssid=%s" % (url_base, api, b['ssid'])
+das=urllib.urlopen(done_nodes_url).read()
+
+sys.exit(rtn_code)

--- a/centos-ci/gluster_strfmt/run-test.sh
+++ b/centos-ci/gluster_strfmt/run-test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# 1. download the build log
+# 2. check if the regex(es) are found in the build log
+#
+
+# if anything fails, we'll abort
+set -e
+
+curl -o build.log ${BUILD_LOG}
+
+# Formats to complain about:
+#
+# 1. XXX: warning: format '%XXX' expects argument of type 'XXX', but argument XXX has type 'ssize_t {aka int}' [-Wformat=]
+# 2. XXX: warning: format '%XXX' expects argument of type 'XXX', but argument XXX has type 'size_t {aka unsigned int}' [-Wformat=]
+#
+# Note: the "{aka unsigned int}" and "[-Wformat=]" are only seen in recent
+#        compilers. Also " argument of" seems to be optional.
+
+rm -f warnings.txt
+grep -E ".*: warning: format '%.*' expects( argument of)? type '.*', but argument .* has type 'ssize_t" build.log | tee -a warnings.txt
+grep -E ".+: warning: format '%.+' expects( argument of)? type '.+', but argument .+ has type 'size_t" build.log | tee -a warnings.txt
+
+WARNINGS=$(wc -l < warnings.txt)
+exit ${WARNINGS}


### PR DESCRIPTION
Kaleb is always watching out for these compile warnings (like a good
behaving package maintainer). Here the IRC log from the most recent
occurence, initiating the creation of this new Jenkins job.

    16:08 < kkeithley> lots of *printf format string warnings creeping back in on 32-bit :-(
    16:09 < kkeithley> particularly size_t and ssize_t that should use %z
    16:09 < kkeithley> but don't
    16:32 < ndevos> should we have a job for complaining about that?
    16:33 < ndevos> we could even download and parse http://artifacts.ci.centos.org/gluster/nightly/master/6/i386/build.log every day
    16:54 < kkeithley> +1 to having a job for 32-bit format string warnings
    16:55 < ndevos> kkeithley: give me a regex that can be used to match such a build.log and I'll put it in the CentOS CI
    16:56 < ndevos> kkeithley: or, even the exact warning with XXX in the location that can vary
    16:58 < kkeithley> XXX: warning: format '%ld' expects argument of type 'XXX', but argument XXX has type 'ssize_t {aka int}' [-Wformat=]
    16:58 < kkeithley> XXX: warning: format '%XXX' expects argument of type 'XXX', but argument XXX has type 'ssize_t {aka int}' [-Wformat=]
    16:59 < kkeithley> and XXX: warning: format '%XXX' expects argument of type 'XXX', but argument XXX has type 'size_t {aka int}' [-Wformat=]
    16:59 < kkeithley> https://kojipkgs.fedoraproject.org//work/tasks/1740/14821740/build.log
    17:02 < kkeithley> correction, and XXX: warning: format '%XXX' expects argument of type 'XXX', but argument XXX has type 'size_t {aka unsigned int}' [-Wformat=]
    17:04 < ndevos> kkeithley: I'll use http://artifacts.ci.centos.org/gluster/nightly/master/6/i386/build.log instead, that will get updated every day :)
    17:04 < ndevos> its rather difficult to figure out what path to use from koji
    17:07 < kkeithley> true, on top of which there won't be daily builds in koji
    17:12 < kkeithley> but I only meant the link to koji as a place to look at 32-bit build warnings

Reported-by: Kaleb S KEITHLEY <kkeithle@redhat.com>
Signed-off-by: Niels de Vos <ndevos@redhat.com>