### PR TITLE
centos-ci/gluster_strfmt: only include warnings.txt once

### DIFF
--- a/centos-ci/gluster_strfmt/gluster_strfmt.xml
+++ b/centos-ci/gluster_strfmt/gluster_strfmt.xml
@@ -77,7 +77,7 @@ python jenkins-job.py</command>
             <recipientProviders>
               <hudson.plugins.emailext.plugins.recipients.DevelopersRecipientProvider/>
             </recipientProviders>
-            <attachmentsPattern>warnings.txt</attachmentsPattern>
+            <attachmentsPattern></attachmentsPattern>
             <attachBuildLog>false</attachBuildLog>
             <compressBuildLog>false</compressBuildLog>
             <replyTo>$PROJECT_DEFAULT_REPLYTO</replyTo>


### PR DESCRIPTION
Signed-off-by: Niels de Vos <ndevos@redhat.com>