### PR TITLE
centos-ci/nightly-builds: build 32-bit packages too

### DIFF
--- a/centos-ci/nightly-builds/gluster_nightly-rpm-builds.xml
+++ b/centos-ci/nightly-builds/gluster_nightly-rpm-builds.xml
@@ -52,6 +52,19 @@ GERRIT_BRANCH=master</properties>
         <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
           <configs>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>CENTOS_VERSION=6
+CENTOS_ARCH=i386
+GERRIT_BRANCH=master</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>gluster_build-rpms</projects>
+          <condition>ALWAYS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
+        </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>CENTOS_VERSION=7
 CENTOS_ARCH=x86_64
 GERRIT_BRANCH=release-3.8</properties>
@@ -67,6 +80,19 @@ GERRIT_BRANCH=release-3.8</properties>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>CENTOS_VERSION=6
 CENTOS_ARCH=x86_64
+GERRIT_BRANCH=release-3.8</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>gluster_build-rpms</projects>
+          <condition>ALWAYS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
+        </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>CENTOS_VERSION=6
+CENTOS_ARCH=i386
 GERRIT_BRANCH=release-3.8</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>
@@ -93,6 +119,19 @@ GERRIT_BRANCH=release-3.7</properties>
             <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
               <properties>CENTOS_VERSION=6
 CENTOS_ARCH=x86_64
+GERRIT_BRANCH=release-3.7</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>gluster_build-rpms</projects>
+          <condition>ALWAYS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+          <buildAllNodesWithLabel>false</buildAllNodesWithLabel>
+        </hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>CENTOS_VERSION=6
+CENTOS_ARCH=i386
 GERRIT_BRANCH=release-3.7</properties>
             </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
           </configs>


### PR DESCRIPTION
i386 was missing from the nightly builds. We actually want to do
verification of the build.log after the build with the gluster_strfmt
job. Without the builds, the job is pretty useless.

Signed-off-by: Niels de Vos <ndevos@redhat.com>