### PR TITLE
centos-ci: add test for glusterfs-coreutils

### DIFF
--- a/centos-ci/README.md
+++ b/centos-ci/README.md
@@ -27,6 +27,18 @@ metadata](http://artifacts.ci.centos.org/gluster/nightly/master/7/x86_64/repodat
 for CentOS-7/x86_64 and the nightly Gluster RPMs for the master branch. If the
 metadata has been updated, a new run is attempted.
 
+## glusterfs-coreutils
+Run the upstream functional tests from the
+[glusterfs-coreutils](https://github.com/gluster/glusterfs-coreutils) master
+branch. This test currently installs the nightly builds from the GlusterFS
+Community that are made available on the [CentOS CI Artifacts
+server](http://artifacts.ci.centos.org/gluster/nightly/).
+
+The job checks every two hours for updates of the [yum 
+metadata](http://artifacts.ci.centos.org/gluster/nightly/master/7/x86_64/repodata/repomd.xml)
+for CentOS-7/x86_64 and the nightly Gluster RPMs for the master branch. If the
+metadata has been updated, a new run is attempted.
+
 ## heketi-functional
 Run the upstream functional tests as described in the [Heketi
 README](https://github.com/heketi/heketi/blob/master/tests/functional/README.md).

--- a/centos-ci/glusterfs-coreutils/gluster_coreutils.xml
+++ b/centos-ci/glusterfs-coreutils/gluster_coreutils.xml
@@ -1,0 +1,69 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Run the functional test from glusterfs-coreutils against the latest build of the glusterfs packages. A new run is executed automatically against the nightly builds of the master branch.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.17.1">
+      <projectUrl>https://github.com/gluster/glusterfs-coreutils/</projectUrl>
+      <displayName></displayName>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    <com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty plugin="naginator@1.15">
+      <optOut>false</optOut>
+    </com.chikli.hudson.plugin.naginator.NaginatorOptOutProperty>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>DUFFY_SCRIPT</name>
+          <description>Python script that reserves a machine from Duffy.</description>
+          <defaultValue>https://raw.githubusercontent.com/gluster/glusterfs-patch-acceptance-tests/master/centos-ci/glusterfs-coreutils/jenkins-job.py</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>TEST_SCRIPT</name>
+          <description>Test script to execute on the reserved machine.</description>
+          <defaultValue>https://raw.githubusercontent.com/gluster/glusterfs-patch-acceptance-tests/master/centos-ci/glusterfs-coreutils/run-test.sh</defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <assignedNode>gluster</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <org.jenkinsci.plugins.urltrigger.URLTrigger plugin="urltrigger@0.40">
+      <spec># run every two hours
+H */2 * * *</spec>
+      <triggerLabel>gluster</triggerLabel>
+      <entries>
+        <org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+          <url>http://artifacts.ci.centos.org/gluster/nightly/master/7/x86_64/repodata/repomd.xml</url>
+          <proxyActivated>false</proxyActivated>
+          <checkStatus>false</checkStatus>
+          <statusCode>200</statusCode>
+          <timeout>300</timeout>
+          <checkETag>false</checkETag>
+          <checkLastModificationDate>true</checkLastModificationDate>
+          <inspectingContent>false</inspectingContent>
+          <contentTypes/>
+        </org.jenkinsci.plugins.urltrigger.URLTriggerEntry>
+      </entries>
+      <labelRestriction>true</labelRestriction>
+    </org.jenkinsci.plugins.urltrigger.URLTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>curl -o jenkins-job.py ${DUFFY_SCRIPT}
+python jenkins-job.py</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.1">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
+</project>

--- a/centos-ci/glusterfs-coreutils/jenkins-job.py
+++ b/centos-ci/glusterfs-coreutils/jenkins-job.py
@@ -1,0 +1,48 @@
+#
+# from: https://raw.githubusercontent.com/kbsingh/centos-ci-scripts/master/build_python_script.py
+#
+# This script uses the Duffy node management api to get fresh machines to run
+# your CI tests on. Once allocated you will be able to ssh into that machine
+# as the root user and setup the environ
+#
+# XXX: You need to add your own api key below, and also set the right cmd= line 
+#      needed to run the tests
+#
+# Please note, this is a basic script, there is no error handling and there are
+# no real tests for any exceptions. Patches welcome!
+
+import json, urllib, subprocess, sys, os
+
+print ""
+print "This test is part of the Gluster Jenkins jobs that can be found on GitHub:"
+print " - https://github.com/gluster/glusterfs-patch-acceptance-tests/tree/master/centos-ci"
+print ""
+
+url_base="http://admin.ci.centos.org:8080"
+ver="7"
+arch="x86_64"
+count=1
+script_url=os.getenv("TEST_SCRIPT")
+
+# read the API key for Duffy from the ~/duffy.key file
+fo=open("/home/gluster/duffy.key")
+api=fo.read().strip()
+fo.close()
+
+# build the URL to request the system(s)
+get_nodes_url="%s/Node/get?key=%s&ver=%s&arch=%s&count=%s" % (url_base,api,ver,arch,count)
+
+# request the system
+dat=urllib.urlopen(get_nodes_url).read()
+b=json.loads(dat)
+cmd="""ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s '
+	yum -y install curl &&
+	curl %s | bash -
+'""" % (b['hosts'][0], script_url)
+rtn_code=subprocess.call(cmd, shell=True)
+
+# return the system(s) to duffy
+done_nodes_url="%s/Node/done?key=%s&ssid=%s" % (url_base, api, b['ssid'])
+das=urllib.urlopen(done_nodes_url).read()
+
+sys.exit(rtn_code)

--- a/centos-ci/glusterfs-coreutils/run-test.sh
+++ b/centos-ci/glusterfs-coreutils/run-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# error out on any failure
+set -e
+
+# install EPEL (for "bats") and standard Gluster repo
+yum -y install epel-release centos-release-gluster yum-utils
+
+# enable the repository with nightly builds (master branch only, for now)
+yum-config-manager --add-repo=http://artifacts.ci.centos.org/gluster/nightly/master.repo
+
+# Install and start gluster daemon
+yum -y install glusterfs-server
+systemctl start glusterd
+
+# Install dependencies for glusterfs-coreutils and the tests
+yum -y install git help2man python-gluster readline-devel glusterfs-api-devel libtool bats
+
+# Git clone the source code
+git clone https://github.com/gluster/glusterfs-coreutils.git
+
+# Install glusterfs-coreutils from source
+cd glusterfs-coreutils/
+./autogen.sh
+./configure
+make -j && make install
+
+# Run test script
+./run-tests.sh


### PR DESCRIPTION
After building nightly packages for CentOS-7/x86_64 from the master
branch in the GlusterFS repository, the glusterfs-coreutils need to be
tested against them.

Suggested-by: Anoop C S <anoopcs@redhat.com>
Signed-off-by: Niels de Vos <ndevos@redhat.com>