### PR TITLE
cico/gd2: Install other SCM tools

### DIFF
--- a/centos-ci/glusterd2/run-test.sh
+++ b/centos-ci/glusterd2/run-test.sh
@@ -18,8 +18,8 @@ then
 	export PATH=$PATH:/usr/local/go/bin
 fi
 
-# also needs git, gcc and make
-yum -y install git gcc make
+# also needs git, hg, bzr, svn gcc and make
+yum -y install git mercurial bzr subversion gcc make
 
 mkdir -p go/{src,pkg,bin}
 cd go


### PR DESCRIPTION
`go get` supports mercurial, bazaar and subversion, along with git for
getting packages.

A new dependency for GD2 is served in a mercurial repo, which is
breaking the job.