### PR TITLE
Don't clean up along in watchdog function

### DIFF
--- a/smoke.sh
+++ b/smoke.sh
@@ -63,7 +63,6 @@ function watchdog ()
     if [ ! -z $mount_pid ]; then kill -USR1 $mount_pid; fi
     gluster volume statedump $V
     sleep 5; #Give some time for the statedumps to be generated
-    cleanup;
 }
 
 function finish ()


### PR DESCRIPTION
The gluster logs disappear on failed runs. We only have statedumps. That doesn't look right.