### PR TITLE
centos-ci/nightly-builds: capture build logs on the console

### DIFF
--- a/centos-ci/nightly-builds/build.sh
+++ b/centos-ci/nightly-builds/build.sh
@@ -70,6 +70,7 @@ RESULTDIR=/srv/gluster/nightly/${GERRIT_BRANCH}/${CENTOS_VERSION}/${CENTOS_ARCH}
 /usr/bin/mock \
 	--root epel-${CENTOS_VERSION}-${CENTOS_ARCH} \
 	--resultdir ${RESULTDIR} \
+	--verbose \
 	--rebuild ${SRPM}
 
 pushd ${RESULTDIR}


### PR DESCRIPTION
Signed-off-by: Niels de Vos <ndevos@redhat.com>