### PR TITLE
Improve commit message parsing for finding issue reference

### DIFF
--- a/update-issue.py
+++ b/update-issue.py
@@ -32,16 +32,11 @@ def get_commit_message():
 
 
 def parse_commit_message(msg):
-    regex = re.compile(
-            r'((fixes)|(updates)):\s*(gluster/glusterfs)?#(\d*)',
-            re.I
-    )
+    regex = re.compile(r'(([fF][iI][xX][eE][sS])|([uU][pP][dD][aA][tT][eE][sS])):?\s+(gluster/glusterfs)?#(\d*)')
     bugs = []
     for line in msg.split('\n'):
-        if (line.lower().startswith('fixes') or
-                line.lower().startswith('updates')):
-            if regex.search(line):
-                bugs.append(regex.match(line).group(5))
+        for match in regex.finditer(line):
+            bugs.append(match.group(5))
     return bugs
 
 


### PR DESCRIPTION
Changed the parser code to detect issue references as made in rfc.sh (which is more lenient than the current version).

This was tested as presented in this gist: https://gist.github.com/ShyamsundarR/e012b975ccf5a9d80bffcce0d1b7bf2c

Basically a smaller version of this python code and a sample input file with valid and invalid inputs to test the parser.