### PR TITLE
Reword comment on issues

### DIFF
--- a/update-issue.py
+++ b/update-issue.py
@@ -46,8 +46,8 @@ def parse_commit_message(msg):
 
 
 def comment_on_issues(issues, commit, link, dry_run):
-    comment = ("This patch will update or fix this issue: {}\n"
-               "Commit Message: {}".format(link, commit.split('\n')[0]))
+    comment = ("A patch {} has been posted that references this issue.\n"
+               "  Commit message: {}".format(link, commit.split('\n')[0]))
     for issue in issues:
         comment_issue(issue, comment, dry_run)
 


### PR DESCRIPTION
Reworded comments against issues, to remove references to fixes or updates in the comment (a little more disambiguity), and to more generically refer to any patch that could be posted for the issue (like code, doc, etc. as such commits are also expected and are not necessarily fixes for the issue)