### PR TITLE
Do not override CFLAGS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,8 +34,9 @@ rm -rf $P/scratch;
 mkdir -p $P/scratch;
 cd $P/scratch;
 rm -rf $P/install;
+export CFLAGS="-Wall ${werror}"
 $SRC/configure --prefix=$P/install --with-mountutildir=$P/install/sbin \
                --with-initdir=$P/install/etc --localstatedir=/var \
                --enable-bd-xlator=${bd} --enable-debug --enable-gnfs --silent
-make install CFLAGS="-g -O0 -Wall ${werror}" -j ${nproc}
+make install -j ${nproc}
 cd $SRC;


### PR DESCRIPTION
It seems to break on FreeBSD for some reason, and since --enable-debug
already take care of "-g -O0", we can skip that.