### PR TITLE
centos-ci: do nightly builds for 3.12

### DIFF
--- a/centos-ci/jobs/build_rpms.yml
+++ b/centos-ci/jobs/build_rpms.yml
@@ -20,9 +20,8 @@
     - choice:
         choices:
         - master
-        - release-3.11
+        - release-3.12
         - release-3.10
-        - release-3.8
         description: Gluster branch to build RPMs
         name: GERRIT_BRANCH
     - choice:

--- a/centos-ci/jobs/nightly-rpm-builds.yml
+++ b/centos-ci/jobs/nightly-rpm-builds.yml
@@ -40,33 +40,6 @@
         - project: gluster_build-rpms
           block: false
           predefined-parameters:
-            GERRIT_BRANCH=release-3.8
-
-            CENTOS_VERSION=7
-
-            CENTOS_ARCH=x86_64
-    - trigger-builds:
-        - project: gluster_build-rpms
-          block: false
-          predefined-parameters:
-            GERRIT_BRANCH=release-3.8
-
-            CENTOS_VERSION=6
-
-            CENTOS_ARCH=x86_64
-    - trigger-builds:
-        - project: gluster_build-rpms
-          block: false
-          predefined-parameters:
-            GERRIT_BRANCH=release-3.8
-
-            CENTOS_VERSION=6
-
-            CENTOS_ARCH=i386
-    - trigger-builds:
-        - project: gluster_build-rpms
-          block: false
-          predefined-parameters:
             GERRIT_BRANCH=release-3.10
 
             CENTOS_VERSION=7
@@ -94,7 +67,7 @@
         - project: gluster_build-rpms
           block: false
           predefined-parameters:
-            GERRIT_BRANCH=release-3.11
+            GERRIT_BRANCH=release-3.12
 
             CENTOS_VERSION=7
 
@@ -103,7 +76,7 @@
         - project: gluster_build-rpms
           block: false
           predefined-parameters:
-            GERRIT_BRANCH=release-3.11
+            GERRIT_BRANCH=release-3.12
 
             CENTOS_VERSION=6
 
@@ -112,7 +85,7 @@
         - project: gluster_build-rpms
           block: false
           predefined-parameters:
-            GERRIT_BRANCH=release-3.11
+            GERRIT_BRANCH=release-3.12
 
             CENTOS_VERSION=6
 


### PR DESCRIPTION
3.12 is the current release, and should generate nightly builds for testing.

3.11 and 3.8 are EOL, no further patches will be merged there. These
have been removed from the nightly builds.

Signed-off-by: Niels de Vos <ndevos@redhat.com>