### PR TITLE
nightly-builds: generate a .repo file

### DIFF
--- a/centos-ci/scripts/nightly-builds.sh
+++ b/centos-ci/scripts/nightly-builds.sh
@@ -76,7 +76,23 @@ pushd ${RESULTDIR}
 createrepo_c .
 popd
 
+# create a new .repo file (for new branches, and it prevents cleanup)
+if [ -z "${GIT_VERSION}" ]; then
+    REPO_VERSION='master'
+    REPO_NAME='master'
+else
+    REPO_VERSION=$(sed 's/\.//' <<< ${GIT_VERSION})
+    REPO_NAME=${GERRIT_BRANCH}
+fi
+
+cat > /srv/gluster/nightly/${REPO_NAME}.repo <<< "[gluster-nightly-${REPO_VERSION}]
+name=Gluster Nightly builds (${GERRIT_BRANCH} branch)
+baseurl=http://artifacts.ci.centos.org/gluster/nightly/${GERRIT_BRANCH}/\$releasever/\$basearch
+enabled=1
+gpgcheck=0"
+
 pushd /srv/gluster/nightly
+artifact ${REPO_NAME}.repo
 artifact ${GERRIT_BRANCH}
 popd
 


### PR DESCRIPTION
Until now, adding the .repo file on the artifacts.ci.centos.org server
was done manually. Obviously this can be automated easily enough.

In the (near?) future, the nightly builds will get cleaned out after 30
days. This means that only recently modified contents will stay
available. The .repo files do not change normally, but with
automatically generating them, they are prevented from being garbage
collected.

URL: https://bugs.centos.org/view.php?id=13805 (delete old contents)
Signed-off-by: Niels de Vos <ndevos@redhat.com>