### PR TITLE
nightly-vagrant: add missing dependencies for Vagrant

### DIFF
--- a/centos-ci/nightly-vagrant/run-test.sh
+++ b/centos-ci/nightly-vagrant/run-test.sh
@@ -21,6 +21,8 @@ yum -y install centos-release-scl
 
 # install docker and Vagrant with QEMU
 yum -y install qemu-kvm sclo-vagrant1-vagrant-libvirt
+# Vagrant dependencies are missing, and cause starting a VM to fail
+yum -y install qemu-kvm-tools qemu-img
 
 # Vagrant needs libvirtd running
 systemctl start libvirtd


### PR DESCRIPTION
Vagrant fails to start VMs on certain hypervisors. It seems that the
dependencies for the package are not correct and miss some bits.
Installing qemu-kvm-tools and qemu-img seems to resolve this.

The error that is logged when Vagrant fails to start a VM is like:

  Call to virDomainCreateWithFlags failed: the CPU is incompatible with
  host CPU: Host CPU does not provide required features: svm

The solution has been identified earlier for Heketi.

See-also: 5132671e ("add qemu-kvm to the list of needed bits")
Signed-off-by: Niels de Vos <ndevos@redhat.com>