### PR TITLE
Update the update-issue.py

### DIFF
--- a/update-issue.py
+++ b/update-issue.py
@@ -63,7 +63,7 @@ def comment_on_issues(issues, commit, link, dry_run):
         comment_issue(issue, comment, dry_run)
 
 
-def comment_issue(issue, comment, dry_run):
+def comment_issue(num, comment, dry_run):
     if dry_run:
         print comment
     else:


### PR DESCRIPTION
No longer need to check if a commit message is updated. That's an extra
API call. Might as well change that to one API call. Use
GERRIT_PATCHSET_NUMBER instead of GERRIT_PATCHSET_REVISION. The revision
is a hash and caused instant tracebacks.