### PR TITLE
centos-ci/heketi: add rtalur as admin for triggering tests

### DIFF
--- a/centos-ci/heketi-functional/gluster_heketi-functional.xml
+++ b/centos-ci/heketi-functional/gluster_heketi-functional.xml
@@ -53,7 +53,7 @@
       <spec>H/5 * * * *</spec>
       <latestVersion>3</latestVersion>
       <configVersion>3</configVersion>
-      <adminlist>lpabon, obnoxxx</adminlist>
+      <adminlist>obnoxxx, raghavendra-talur</adminlist>
       <allowMembersOfWhitelistedOrgsAsAdmin>false</allowMembersOfWhitelistedOrgsAsAdmin>
       <orgslist></orgslist>
       <cron>H/5 * * * *</cron>


### PR DESCRIPTION
Luis Pabon is not maintaining Heketi anymore and transferred the
responsibilities to Michael Adam and Raghavendra Talur. The maintainers
are expected to be able to trigger the tests once a pull-request has
been sufficiently reviewd.

Signed-off-by: Niels de Vos <ndevos@redhat.com>