### PR TITLE
centos-ci/gluster-kubernetes: add new test for pull-requests

### DIFF
--- a/centos-ci/jobs/gluster-kubernetes.yml
+++ b/centos-ci/jobs/gluster-kubernetes.yml
@@ -1,0 +1,45 @@
+- job:
+    name: gluster_kubernetes
+    node: gluster
+    description: Run the complex test from gluster-kubernetes. Tests are
+      triggered for a pull-request after one of the repository admins approves
+      it (with standard Jenkins GitHub commands).
+    project-type: freestyle
+    concurrent: true
+
+    scm:
+    - git:
+        url: https://github.com/gluster/glusterfs-patch-acceptance-tests.git
+        branches:
+        - origin/master
+
+    properties:
+    - github:
+        url: https://github.com/gluster/gluster-kubernetes/
+
+    triggers:
+    - github-pull-request:
+        admin-list:
+        - jarrpa
+        - obnoxxx
+        white-list:
+        - jarrpa
+        - obnoxxx
+        cron: */5 * * * *
+
+    builders:
+    - shell: !include-raw: ../scripts/get-node.sh
+    - shell: centos-ci/scripts/bootstrap.sh gluster-kubernetes.sh "ghprbPullId=${ghprbPullId}"
+
+    publishers:
+    - post-tasks:
+        - matches:
+            # "Building remotely" should always be in the build console output
+            - log-text: Building remotely
+          script:
+            !include-raw: ../scripts/return-node.sh
+
+    wrappers:
+    - ansicolor:
+        colormap: xterm
+    - timestamps

--- a/centos-ci/scripts/gluster-kubernetes.sh
+++ b/centos-ci/scripts/gluster-kubernetes.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# if anything fails, we'll abort
+set -e
+
+# TODO: disable debugging
+set -x
+
+# we get the code from git and configure VMs with Ansible
+yum -y install git ansible
+
+# enable the SCL repository for Vagrant
+yum -y install centos-release-scl
+
+# install Vagrant with QEMU
+#
+# WARNING: adding sclo-vagrant1-vagrant on the "yum install" command makes it
+#          work fine. Without sclo-vagrant1-vagrant the following error occurs
+#          and starting the VMs fails:
+#
+#    Call to virDomainCreateWithFlags failed: the CPU is incompatible with host
+#    CPU: Host CPU does not provide required features: svm
+#
+yum -y install qemu-kvm sclo-vagrant1-vagrant sclo-vagrant1-vagrant-libvirt \
+               qemu-kvm-tools qemu-img
+
+# Vagrant needs libvirtd running
+systemctl start libvirtd
+
+# Log the virsh capabilites so that we know the
+# environment in case something goes wrong.
+virsh capabilities
+
+git clone https://github.com/gluster/gluster-kubernetes.git
+pushd gluster-kubernetes
+
+# by default we clone the master branch, but maybe this was triggered through a PR?
+if [ -n "${ghprbPullId}" ]
+then
+	git fetch origin pull/${ghprbPullId}/head:pr_${ghprbPullId}
+	git checkout pr_${ghprbPullId}
+	
+	# Now rebase on top of master
+	git rebase master
+	if [ $? -ne 0 ] ; then
+	    echo "Unable to automatically merge master. Please rebase your patch"
+	    exit 1
+	fi
+fi
+
+# set the current working directory so that the script find the Vagrantfile
+pushd vagrant
+scl enable sclo-vagrant1 ../tests/complex/run.sh


### PR DESCRIPTION
A new Jenkins job in the CentOS CI has been added:
 - https://ci.centos.org/view/Gluster/gluster_gluster-kubernetes

This job gets executed when an admin of the gluster-kubernetes
repository (admins are listed in the `jobs/gluster-kubernetes.yml`
file) leaves a comment in the GitHub Pull-Request with the following
phrases:
 - ok to test
 - test this please
 (from https://github.com/jenkinsci/ghprb-plugin/blob/master/README.md)

Updates: gluster/gluster-kubernetes#23
Signed-off-by: Niels de Vos <ndevos@redhat.com>