### PR TITLE
centos-ci/gluster-kubernetes: post test status updates a "centos-ci"

### DIFF
--- a/centos-ci/jobs/gluster-kubernetes.yml
+++ b/centos-ci/jobs/gluster-kubernetes.yml
@@ -25,7 +25,8 @@
         white-list:
         - jarrpa
         - obnoxxx
-        cron: */5 * * * *
+        cron: H/5 * * * *
+        status-context: centos-ci
 
     builders:
     - shell: !include-raw: ../scripts/get-node.sh


### PR DESCRIPTION
The status updates were not showing in the Pull-Requests when tests got
started or after finishing. It seems that setting the status-context to
the "centos-ci" label makes this work correctly.

In addition to that, address the warning about the cronjob:
  Spread load evenly by using ‘H/5 * * * *’ rather than ‘*/5 * * * *’

Updates: gluster/gluster-kubernetes#23
Signed-off-by: Niels de Vos <ndevos@redhat.com>