### PR TITLE
centos-ci:heketi: fix regression introduced by last patch

### DIFF
--- a/centos-ci/heketi-functional/run-test.sh
+++ b/centos-ci/heketi-functional/run-test.sh
@@ -92,7 +92,7 @@ fi
 
 # need to prevent sudo from disabling the SCL
 # PR: https://github.com/heketi/heketi/pull/395
-grep -q ^_sudo lib.sh || ( curl https://github.com/heketi/heketi/commit/981f84b2f7cf6ea39754a0fa275fdc86eb3affbb.patch | git apply )
+git grep -q ^_sudo tests/functional/lib.sh || ( curl https://github.com/heketi/heketi/commit/981f84b2f7cf6ea39754a0fa275fdc86eb3affbb.patch | git apply )
 
 # time to run the tests!
 


### PR DESCRIPTION
462f0d95ce38301a788fde8945d23631144a33dc
changed the directory from which to check for
the _sudo in tests/functional/lib.sh.
Hence the check failed.

This patch fixes this by using the proper relative
path (and using git grep instead of grep, for what
it's worth...).

Signed-off-by: Michael Adam <obnox@samba.org>