### PR TITLE
centos-ci:heketi: fix an error running make under scl

### DIFF
--- a/centos-ci/heketi-functional/run-test.sh
+++ b/centos-ci/heketi-functional/run-test.sh
@@ -108,7 +108,7 @@ TEST_TARGET="test-functional"
 RC=0
 make -q "${TEST_TARGET}" > /dev/null 2>&1 || RC=$?
 if [[ ${RC} -eq 1 ]]; then
-	scl enable sclo-vagrant1 make "${TEST_TARGET}"
+	echo make "${TEST_TARGET}" | scl enable sclo-vagrant1 bash
 else
 	# fallback for old branches that did not
 	# have the "test-functional target yet


### PR DESCRIPTION
scl apparently can't execute make directly.
Copy the echo-pipe-bash trick from the vagrant-nightly directory.

Signed-off-by: Michael Adam <obnox@samba.org>