### PR TITLE
centos-ci/heketi-functional: fix the notation of the admin list

### DIFF
--- a/centos-ci/heketi-functional/gluster_heketi-functional.xml
+++ b/centos-ci/heketi-functional/gluster_heketi-functional.xml
@@ -53,7 +53,7 @@
       <spec>H/5 * * * *</spec>
       <latestVersion>3</latestVersion>
       <configVersion>3</configVersion>
-      <adminlist>obnoxxx, raghavendra-talur, phlogistonjohn, nixpanic, jarrpa, humblec, SaravanaStorageNetwork, purpleidea</adminlist>
+      <adminlist>obnoxxx raghavendra-talur phlogistonjohn nixpanic jarrpa humblec SaravanaStorageNetwork purpleidea</adminlist>
       <allowMembersOfWhitelistedOrgsAsAdmin>false</allowMembersOfWhitelistedOrgsAsAdmin>
       <orgslist></orgslist>
       <cron>H/5 * * * *</cron>


### PR DESCRIPTION
It seems the list of admins that may trigger tests need to be separated
by spaces. The Jenkins webui gives the following message when commas are
used:

  GitHub username may only contain alphanumeric characters or dashes and
  cannot begin with a dash. Separate them with whitespaces.

Signed-off-by: Niels de Vos <ndevos@redhat.com>