### PR TITLE
centos-ci/nightly-vagrant: update the URL to download boxes from

### DIFF
--- a/centos-ci/nightly-vagrant/run-test.sh
+++ b/centos-ci/nightly-vagrant/run-test.sh
@@ -34,6 +34,9 @@ yum -y install git rsync
 yum -y install epel-release
 yum -y install ansible
 
+# Vagrant changed the download location of the boxes
+export VAGRANT_SERVER_URL="https://vagrantcloud.com"
+
 # clone the repository, github is faster than our Gerrit
 #git clone https://review.gluster.org/glusterfs
 git clone https://github.com/gluster/glusterfs


### PR DESCRIPTION
It seems vagrant boxes can no longer be downloaded from
"https://atlas.hashicorp.com" and all boxes should be downloaded from
"https://vagrantcloud.com". This change was done in
hashicorp/vagrant@5f955c3 .

See-also: sclorg-distgit/vagrant#3
Signed-off-by: Niels de Vos <ndevos@redhat.com>