### PR TITLE
centos-ci/gluster-kubernetes: run the job once a day

### DIFF
--- a/centos-ci/jobs/gluster-kubernetes.yml
+++ b/centos-ci/jobs/gluster-kubernetes.yml
@@ -18,6 +18,7 @@
         url: https://github.com/gluster/gluster-kubernetes/
 
     triggers:
+    - timed: '@daily'
     - github-pull-request:
         admin-list:
         - jarrpa

--- a/centos-ci/scripts/gluster-kubernetes.sh
+++ b/centos-ci/scripts/gluster-kubernetes.sh
@@ -27,6 +27,9 @@ yum -y install qemu-kvm sclo-vagrant1-vagrant sclo-vagrant1-vagrant-libvirt \
 # Vagrant needs libvirtd running
 systemctl start libvirtd
 
+# Vagrant changed the download location of the boxes
+export VAGRANT_SERVER_URL="https://vagrantcloud.com"
+
 # Log the virsh capabilites so that we know the
 # environment in case something goes wrong.
 virsh capabilities


### PR DESCRIPTION
This PR contains two changes that make the `gluster-kubernetes` job functional again and run it once every day.

This was suggested by @phlogistonjohn and @obnoxxx, but I can't add them as reviewers?