### PR TITLE
centos-ci/heketi-functional: run the job once a day

### DIFF
--- a/centos-ci/heketi-functional/gluster_heketi-functional.xml
+++ b/centos-ci/heketi-functional/gluster_heketi-functional.xml
@@ -49,6 +49,9 @@
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>
+    <hudson.triggers.TimerTrigger>
+      <spec>@daily</spec>
+    </hudson.triggers.TimerTrigger>
     <org.jenkinsci.plugins.ghprb.GhprbTrigger plugin="ghprb@1.33.1">
       <spec>H/5 * * * *</spec>
       <latestVersion>3</latestVersion>


### PR DESCRIPTION
We currently only run the job on GitHub PullRequests. But we consume
components from other projects, so it is better to also run
periodically. Once a day should be sufficient, and we're nowhere near
the limit of resources we can consume.

By default the scripts already clone/checkout the master branch, with
the PR as option. No further changes to the scripts are needed atm.

Suggested-by: John Mulligan <jmulliga@redhat.com>
Signed-off-by: Niels de Vos <ndevos@redhat.com>