### PR TITLE
Add a handler to run test server script task

### DIFF
--- a/distributed-tests/distributed-server.yml
+++ b/distributed-tests/distributed-server.yml
@@ -125,3 +125,12 @@
     shell: nohup ./distributed-test-runner.py --server &
     args:
       chdir: /srv/glusterfs/extras/distributed-testing
+    notify:
+      - Copy glusterfs logs
+
+  handlers:
+    - name:  Copy glusterfs logs
+      synchronize:
+        src: '/var/log/glusterfs'
+        dest: '/tmp/failed-tests'
+        mode: pull

--- a/distributed-tests/distributed-server.yml
+++ b/distributed-tests/distributed-server.yml
@@ -125,12 +125,11 @@
     shell: nohup ./distributed-test-runner.py --server &
     args:
       chdir: /srv/glusterfs/extras/distributed-testing
-    notify:
-      - Copy glusterfs logs
 
-  handlers:
-    - name:  Copy glusterfs logs
-      synchronize:
-        src: '/var/log/glusterfs'
-        dest: '/tmp/failed-tests'
-        mode: pull
+  - name:  Copy glusterfs logs
+    synchronize:
+      src: '/var/log/glusterfs'
+      dest: '/tmp/failed-tests'
+      mode: pull
+    tags:
+      - copy_logs


### PR DESCRIPTION
This handler will copy the logs from '/var/log/glusterfs' of  connected servers to tester machine

Signed-off-by: Deepshikha Khandelwal <dkhandel@redhat.com>