### PR TITLE
github: allow no approval check for bugs

### DIFF
--- a/github/handle_github.py
+++ b/github/handle_github.py
@@ -85,6 +85,11 @@ class GitHubHandler(object):
                     spec_approved = True
                 if label.name == "DocApproved":
                     doc_approved = True
+                if label.name == "Type:Bug":
+                    error = "No Approval check for 'bugs'"
+                    print(error)
+                    self.error_string.append(error)
+                    return True
             if not spec_approved:
                 error = "Missing SpecApproved flag on Issue {}".format(num)
                 print(error)


### PR DESCRIPTION
This helps to have both bugs and feature requests in GitHub issues for glusterfs project.

Signed-off-by: Amar Tumballi <amarts@redhat.com>