### PR TITLE
Add glusterd2 tests

### DIFF
--- a/glusterd2-test.sh
+++ b/glusterd2-test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# NOTE:
+# This script assumes that glusterfs source (with relevant gerrit change) has
+# been built and/or installed.
+# Required dependencies:
+#         yum -y install golang git mercurial bzr subversion gcc make
+
+# echo commands
+set -x
+
+# if anything fails, we'll abort
+set -e
+
+# set up GOPATH
+mkdir -p go/{pkg,src,bin}
+export GOPATH=$PWD/go
+export PATH=$PATH:$GOPATH/bin
+
+# clone glusterd2 source into GOPATH
+export GD2GIT=https://github.com/gluster/glusterd2.git
+export GD2SRC=$GOPATH/src/github.com/gluster/glusterd2
+mkdir -p $GD2SRC
+git clone $GD2GIT $GD2SRC
+cd $GD2SRC
+
+# install the build and test requirements
+./scripts/install-reqs.sh
+
+# install vendored dependencies
+make vendor-install
+
+# build glusterd2 and cli
+make glusterd2
+make glustercli
+make gd2conf
+
+# run unit tests and other static tests (not really needed for glusterfs tests)
+make test TESTOPTIONS=-v
+
+# run functional tests
+make functest


### PR DESCRIPTION
These tests are intended to be run as non-voting job (for now) against
glusterfs Gerrit changes. It has been verified that these tests pass on
a centos 7 machine.

This needs to be a non-voting job as we have one test (TestBitrot) that
fails spuriously. Once that is resolved, we can make this a voting job.

Signed-off-by: Prashanth Pai <ppai@redhat.com>