### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,6 +28,7 @@ esac
 if type rpm >/dev/null 2>&1; then
     rpm -qa | grep glusterfs | xargs --no-run-if-empty rpm -e
 fi
+rm -f .python-shebangs
 ./autogen.sh;
 P=/build;
 rm -rf $P/scratch;


### PR DESCRIPTION
whatever cleans the workspace where the tree is cloned apparently just does `rm -rf *` which does not delete .foo, and in particular the .python-shebangs file from previous build in this workspace