### PR TITLE
Check the status of github issue

### DIFF
--- a/github/handle_github.py
+++ b/github/handle_github.py
@@ -80,6 +80,14 @@ class GitHubHandler(object):
                 return True
             spec_approved = False
             doc_approved = False
+            issue_closed = False
+            if issue.is_closed() == True:
+                issue_closed = True
+            if issue_closed:
+                error = "Issue #{} has been closed".format(num)
+                print(error)
+                self.error_string.append(error)
+                return False
             for label in issue.labels:
                 if label.name == "SpecApproved":
                     spec_approved = True


### PR DESCRIPTION
This commit will check the status of Github issue before do any further label check. This will start failing smoke on commits that use closed github issue. Link to the bug filed: https://bugzilla.redhat.com/show_bug.cgi?id=1597351

Signed-off-by: Deepshikha Khandelwal<dkhandel@redhat.com>