### PR TITLE
"--enable-bd-xlator" is no longer present in code base

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,6 @@ cd $P/scratch;
 rm -rf $P/install;
 $SRC/configure --prefix=$P/install --with-mountutildir=$P/install/sbin \
                --with-initdir=$P/install/etc --localstatedir=/var \
-               --enable-bd-xlator=${bd} --enable-debug --enable-gnfs --silent
+               --enable-debug --enable-gnfs --silent
 make install CFLAGS="-Wall ${werror} -Wno-cpp" -j ${nproc}
 cd $SRC;


### PR DESCRIPTION
bd translator got removed from code base through the following changes:

https://review.gluster.org/#/c/glusterfs/+/21812/
https://review.gluster.org/#/c/glusterfs/+/20702/

Signed-off-by: Anoop C S <anoopcs@redhat.com>