### PR TITLE
github: handle error in commit message

### DIFF
--- a/github/commit.py
+++ b/github/commit.py
@@ -73,12 +73,19 @@ class CommitHandler(object):
         if self.revision_number == 1:
             return issues
 
-        issues = [x['id'] for x in issues]
+        current_issues = [x['id'] for x in issues]
         oldmessage = self.get_commit_message_from_gerrit()
         oldissues = self.parse_commit_message(oldmessage)
         oldissues = [x['id'] for x in oldissues]
         print("Old issues: {}".format(oldissues))
-        newissues = list(set(issues) - (set(issues) & set(oldissues)))
+        newissues_list = list(set(current_issues) - (set(current_issues) & set(oldissues)))
+        print("New issues: {}".format(newissues_list))
+        newissues = []
+        # We need to return a list of 'github objects', not a list of integers
+        for issue in newissues_list:
+            for i in issues:
+                if i['id'] == issue:
+                    newissues.append(i)
         return newissues
 
     def parse_commit_message(self, msg):


### PR DESCRIPTION
Handles the error like below:
```
  Traceback (most recent call last):
     File "/opt/qa/github/handle_github.py", line 187, in <module>
       main(ARGS.repo, ARGS.dry_run, ARGS.comment_file)
     File "/opt/qa/github/handle_github.py", line 165, in main
       github.comment_on_issues(newissues, commit_msg)
     File "/opt/qa/github/handle_github.py", line 47, in comment_on_issues
       self._comment_on_issue(issue['id'], comment)
   TypeError: string indices must be integers
```

This was not noticed before because we returned 'issues' as is, when patchset is 1.

Signed-off-by: Amar Tumballi <amarts@redhat.com>