### PR TITLE
Use "--without-libtirpc" during configure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,6 @@ cd $P/scratch;
 rm -rf $P/install;
 $SRC/configure --prefix=$P/install --with-mountutildir=$P/install/sbin \
                --with-initdir=$P/install/etc --localstatedir=/var \
-               --enable-debug --enable-gnfs --silent
+               --enable-debug --enable-gnfs --without-libtirpc --silent
 make install CFLAGS="-Wall ${werror} -Wno-cpp" -j ${nproc}
 cd $SRC;

--- a/distributed-tests/setup.yml
+++ b/distributed-tests/setup.yml
@@ -138,7 +138,7 @@
   - name: Build glusterfs
     shell: |
       ./autogen.sh
-      ./configure --enable-debug --enable-gnfs --silent
+      ./configure --enable-debug --enable-gnfs --without-libtirpc --silent
       make install
     args:
       chdir: '{{ scratchdir }}/glusterfs'


### PR DESCRIPTION
To avoid the following warning, intentionally specify that we are not
using libtirpc.

"libtirpc (and/or ipv6-default) were enabled but libtirpc-devel is not
installed. Disabling libtirpc and ipv6-default and falling back to
legacy glibc rpc headers. This is a transitional warning message.
Eventually it will be an error message."

Signed-off-by: Anoop C S <anoopcs@redhat.com>