### PR TITLE
Do a cleaner cleanup

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -11,11 +11,14 @@ V=patchy;
 
 function cleanup()
 {
-    killall -15 glusterfs glusterfsd glusterd glusterd 2>&1 || true;
-    killall -9 glusterfs glusterfsd glusterd glusterd 2>&1 || true;
+    killall -15 glusterfs glusterfsd glusterd 2>&1 || true;
+    killall -9  glusterfs glusterfsd glusterd 2>&1 || true;
     pkill /opt/qa/regression.sh 2>&1
     umount -l $M 2>&1 || true;
-    rm -rf /var/lib/glusterd/* /etc/glusterd/* /var/log/glusterfs/* $P/export;
+    rm -rf /var/lib/glusterd/* /var/log/glusterfs/.cmd_log_history /etc/glusterd/* /var/log/glusterfs/* $P/export;
+
+    rm -f /var/run/glusterd.socket
+    rm -rf /var/run/gluster/ 
 }
 
 


### PR DESCRIPTION
Clean /var/run/gluster, since there is a ton of socket here
(cleaned on reboot)

Do not try to kill glusterd twice

Remove /var/log/glusterfs/.cmd_log_history so we do not need to do
in others scripts

Remove /var/run/glusterd.socket so we can also remove that from others scripts