### PR TITLE
Increase the limit to 5 minutes

### DIFF
--- a/smoke.sh
+++ b/smoke.sh
@@ -5,7 +5,7 @@ set -e;
 M=/mnt;
 P=/build;
 H=$(hostname);
-T=200;
+T=300;
 V=patchy;
 export PATH=$PATH:$P/install/sbin
 


### PR DESCRIPTION
When we merged new posix compliance test, we found out that the tests
were taking more than 200 seconds, and thus, the watchdog function killed
all processes, making the test fail. See https://github.com/gluster/glusterfs-patch-acceptance-tests/pull/199
for the details.