### PR TITLE
Disable set -e, since it make the script stop at pkill

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e;
+#set -e;
 
 M=/mnt;
 P=/build;


### PR DESCRIPTION
Since pkill is not matching anything, it fail, and set -e stop
the whole script.