### PR TITLE
add 'disable-linux-io_uring' flag for el-7 builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,12 +25,15 @@ case $(uname -s) in
         werror=""
 esac
 
+io_uring=""
+brickmux=""
 case $JOB_NAME in
     'gh_regression-test-with-multiplex'|'gh_regression-on-demand-multiplex')
         brickmux="--enable-brickmux"
         ;;
-    *)
-        brickmux=""
+    'gh_smoke-centos7'|'gh_devrpm-el7')
+        io_uring="--disable-linux-io_uring"
+        ;;
 esac
 
 if type rpm >/dev/null 2>&1; then
@@ -44,6 +47,6 @@ cd $P/scratch;
 rm -rf $P/install;
 $SRC/configure --prefix=$P/install --with-mountutildir=$P/install/sbin \
                --with-initdir=$P/install/etc --localstatedir=/var \
-               --enable-debug --enable-gnfs --silent ${brickmux}
+               --enable-debug --enable-gnfs --silent ${brickmux} ${io_uring}
 make install CFLAGS="-Wall ${werror} -Wno-cpp" -j ${nproc}
 cd $SRC;


### PR DESCRIPTION
https://github.com/gluster/glusterfs/pull/2060 fails on el-7 because
liburing-devel is not available on them. Hence adding this flag to our
build script so that the PR passes.

Note: 2060 is what introduces the 'disable-linux-io_uring' flag but we
can add it here even before it is merged because ./configure will
complain, but won't error out if an un-recognized (yet) option is given.

Signed-off-by: Ravishankar N <ravishankar@redhat.com>