### PR TITLE
Fix update of path-based environment variables

### DIFF
--- a/regression.sh
+++ b/regression.sh
@@ -47,10 +47,10 @@ getliblistfromcore() {
 PY_VER=$(python -c "import sys; print sys.version[:3]")
 
 # Point to the build we're testing
-export PATH="${BASE}/sbin:${PATH}"
-export PYTHONPATH="${BASE}/lib/python${PY_VER}/site-packages:${PYTHONPATH}"
-export LIBRARY_PATH="${BASE}/lib:${LIBRARY_PATH}"
-export LD_LIBRARY_PATH="${BASE}/lib:${LD_LIBRARY_PATH}"
+export PATH="${BASE}/sbin${PATH:+:${PATH}}"
+export PYTHONPATH="${BASE}/lib/python${PY_VER}/site-packages${PYTHONPATH:+:${PYTHONPATH}}"
+export LIBRARY_PATH="${BASE}/lib${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+export LD_LIBRARY_PATH="${BASE}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
 # save core_patterns
 case $(uname -s) in


### PR DESCRIPTION
Avoid that modified path-based variables end with ':'.

When this was done with 'LD_PRELOAD_PATH' variable, it caused that all
executables try to find its dynamic libraries in the current directory.

Fixes: #208
Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>