### PR TITLE
Change the case of gh_regression-test-with-multiplex to set the flags…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,9 +29,9 @@ io_uring=""
 brickmux=""
 case $JOB_NAME in
     'gh_regression-test-with-multiplex'|'gh_regression-on-demand-multiplex')
-        brickmux="--enable-brickmux"
+        brickmux="--enable-brickmux"; io_uring="--disable-linux-io_uring"
         ;;
-    'gh_smoke-centos7'|'gh_devrpm-el7'|'gh_centos7-regression'|'gh_regression-on-demand-full-run'|'gh_regression-test-with-multiplex'|'gh_regression-test-burn-in')
+    'gh_smoke-centos7'|'gh_devrpm-el7'|'gh_centos7-regression'|'gh_regression-on-demand-full-run'|'gh_regression-test-burn-in')
         io_uring="--disable-linux-io_uring"
         ;;
 esac


### PR DESCRIPTION
The job gh_regression-test-with-multiplex was failing.
 
On observation I found out that the flags are not getting set properly due to the duplicated case names.
 
I have introduced a new case for the job - gh_regression-test-with-multiplex, to set both the flags --enable-brickmux and --disable-linux-io_uring in it.